### PR TITLE
Added the ability to disable data storage (i.e. disk writing)

### DIFF
--- a/python/minidaqapp/fake_app_confgen.py
+++ b/python/minidaqapp/fake_app_confgen.py
@@ -40,6 +40,7 @@ def generate(
         TRIGGER_RATE_HZ = 1.0,
         DATA_FILE="./frames.bin",
         OUTPUT_PATH=".",
+        DISABLE_OUTPUT=False
     ):
     
     trigger_interval_ticks = math.floor((1/TRIGGER_RATE_HZ) * CLOCK_SPEED_HZ/DATA_RATE_SLOWDOWN_FACTOR)
@@ -188,7 +189,11 @@ def generate(
 
     startpars = cmd.StartParams(run=RUN_NUMBER)
     startcmd = mcmd("start", [
-            ("datawriter", startpars),
+            ("datawriter", dw.StartParams(
+                run=RUN_NUMBER,
+                disable_data_storage=DISABLE_OUTPUT,
+                data_storage_prescale=1
+              )),
             ("ffr", startpars),
             ("datahandler_.*", startpars),
             ("fake_source", startpars),
@@ -256,8 +261,9 @@ if __name__ == '__main__':
     @click.option('-t', '--trigger-rate-hz', default=1.0)
     @click.option('-d', '--data-file', type=click.Path(), default='./frames.bin')
     @click.option('-o', '--output-path', type=click.Path(), default='.')
+    @click.option('--disable-data-storage', is_flag=True)
     @click.argument('json_file', type=click.Path(), default='minidaq-app-fake-readout.json')
-    def cli(number_of_data_producers, data_rate_slowdown_factor, run_number, trigger_rate_hz, data_file, output_path, json_file):
+    def cli(number_of_data_producers, data_rate_slowdown_factor, run_number, trigger_rate_hz, data_file, output_path, disable_data_storage, json_file):
         """
           JSON_FILE: Input raw data file.
           JSON_FILE: Output json configuration file.
@@ -270,7 +276,8 @@ if __name__ == '__main__':
                     RUN_NUMBER = run_number, 
                     TRIGGER_RATE_HZ = trigger_rate_hz,
                     DATA_FILE = data_file,
-                    OUTPUT_PATH = output_path
+                    OUTPUT_PATH = output_path,
+                    DISABLE_OUTPUT = disable_data_storage
                 ))
 
         print(f"'{json_file}' generation completed.")


### PR DESCRIPTION
Giovanna,
I would like to request your review of the changes on this branch.

These changes add the ability to disable data storage (i.e. disk writing) when creating JSON configuration files from python/minidaqapp/fake-app-gen.py.

A sample command for doing that is the following:

- `python -m minidaqapp.fake_app_confgen -d ./frames.bin -o '.' --disable-data-storage my_minidaq_config.json`

All of the underlying changes (for example, in the _dfmodules_) repository have already been merged to their respective _develop_ branches, so you should be able to use [these instructions](https://github.com/DUNE-DAQ/minidaqapp/wiki/Instructions-for-setting-up-a-v2.2.0--to--v2.4.0-development-environment) to test this change.

Of course, if anyone else also wants to review this change, that would be certainly welcome.