### PR TITLE
Populate "initial_token_count" parameter of TriggerDecisionEmulator. Use

### DIFF
--- a/python/minidaqapp/fake_app_confgen.py
+++ b/python/minidaqapp/fake_app_confgen.py
@@ -130,6 +130,12 @@ def generate(
         data=init_specs
     )
 
+    if TOKEN_COUNT > 0:
+        df_token_count = 0
+        trigemu_token_count = TOKEN_COUNT
+    else:
+        df_token_count = -1 * TOKEN_COUNT
+        trigemu_token_count = 0
 
     confcmd = mrccmd("conf", "INITIAL", "CONFIGURED",[
                 ("tde", tde.ConfParams(
@@ -146,7 +152,8 @@ def generate(
                         # emitted per (wall-clock) second, rather than being
                         # spaced out further
                         trigger_interval_ticks=trigger_interval_ticks,
-                        clock_frequency_hz=CLOCK_SPEED_HZ/DATA_RATE_SLOWDOWN_FACTOR                    
+                        clock_frequency_hz=CLOCK_SPEED_HZ/DATA_RATE_SLOWDOWN_FACTOR,
+                        initial_token_count=trigemu_token_count
                         )),
                 ("rqg", rqg.ConfParams(
                         map=rqg.mapgeoidqueue([
@@ -157,7 +164,7 @@ def generate(
                             general_queue_timeout=QUEUE_POP_WAIT_MS
                         )),
                 ("datawriter", dw.ConfParams(
-                            initial_token_count=TOKEN_COUNT,
+                            initial_token_count=df_token_count,
                             data_store_parameters=hdf5ds.ConfParams(
                                 name="data_store",
                                 # type = "HDF5DataStore", # default

--- a/python/minidaqapp/flx_app_confgen.py
+++ b/python/minidaqapp/flx_app_confgen.py
@@ -133,6 +133,12 @@ def generate(
         data=init_specs
     )
 
+    if TOKEN_COUNT > 0:
+        df_token_count = 0
+        trigemu_token_count = TOKEN_COUNT
+    else:
+        df_token_count = -1 * TOKEN_COUNT
+        trigemu_token_count = 0
 
     confcmd = mrccmd("conf", "INITIAL", "CONFIGURED",[
                 ("tde", tde.ConfParams(
@@ -145,7 +151,8 @@ def generate(
                         # The delay is set to put the trigger well within the latency buff
                         trigger_delay_ticks=math.floor( 2* CLOCK_SPEED_HZ),
                         trigger_interval_ticks=trigger_interval_ticks,
-                        clock_frequency_hz=CLOCK_SPEED_HZ                    
+                        clock_frequency_hz=CLOCK_SPEED_HZ,
+                        initial_token_count=trigemu_token_count                    
                         )),
                 ("rqg", rqg.ConfParams(
                         map=rqg.mapgeoidqueue([
@@ -156,7 +163,7 @@ def generate(
                             general_queue_timeout=QUEUE_POP_WAIT_MS
                         )),
                 ("datawriter", dw.ConfParams(
-                            initial_token_count=TOKEN_COUNT,
+                            initial_token_count=df_token_count,
                             data_store_parameters=hdf5ds.ConfParams(
                                 name="data_store",
                                 # type = "HDF5DataStore", # default

--- a/python/minidaqapp/rudf_trg.py
+++ b/python/minidaqapp/rudf_trg.py
@@ -83,7 +83,7 @@ def generate_df(
         OUTPUT_PATH=".",
         DISABLE_OUTPUT=False,
         FLX_INPUT=True,
-        TOKEN_COUNT=10
+        TOKEN_COUNT=0
     ):
     """Generate the json configuration for the readout and DF process"""
    
@@ -334,6 +334,7 @@ def generate_trigemu(
         TRIGGER_RATE_HZ = 1.0,
         DATA_FILE="./frames.bin",
         OUTPUT_PATH=".",
+        TOKEN_COUNT=10
     ):
     """Generate the json config for the TriggerDecisionEmulator process"""
     
@@ -416,7 +417,8 @@ def generate_trigemu(
                         # emitted per (wall-clock) second, rather than being
                         # spaced out further
                         trigger_interval_ticks=trg_interval_ticks,
-                        clock_frequency_hz=CLOCK_SPEED_HZ/DATA_RATE_SLOWDOWN_FACTOR                    
+                        clock_frequency_hz=CLOCK_SPEED_HZ/DATA_RATE_SLOWDOWN_FACTOR,
+                        initial_token_count=TOKEN_COUNT                    
                         )),
             ])
 
@@ -494,6 +496,13 @@ if __name__ == '__main__':
             "timesync": f"tcp://{host_ip_df}:12347"
         }
 
+        if token_count > 0:
+            df_token_count = 0
+            trigemu_token_count = token_count
+        else:
+            df_token_count = -1 * token_count
+            trigemu_token_count = 0
+
         with open(json_file_trigemu, 'w') as f:
             f.write(generate_trigemu(
                     network_endpoints,
@@ -502,7 +511,8 @@ if __name__ == '__main__':
                     RUN_NUMBER = run_number, 
                     TRIGGER_RATE_HZ = trigger_rate_hz,
                     DATA_FILE = data_file,
-                    OUTPUT_PATH = output_path
+                    OUTPUT_PATH = output_path,
+                    TOKEN_COUNT = trigemu_token_count
                 ))
 
         with open(json_file_df, 'w') as f:
@@ -517,7 +527,7 @@ if __name__ == '__main__':
                     OUTPUT_PATH = output_path,
                     DISABLE_OUTPUT = disable_data_storage,
                     FLX_INPUT = use_felix,
-                    TOKEN_COUNT = token_count
+                    TOKEN_COUNT = df_token_count
                 ))
 
     cli()

--- a/python/minidaqapp/rudf_trg_separate_cmds.py
+++ b/python/minidaqapp/rudf_trg_separate_cmds.py
@@ -83,7 +83,7 @@ def generate_df(
         OUTPUT_PATH=".",
         DISABLE_OUTPUT=False,
         FLX_INPUT=True,
-        TOKEN_COUNT=10
+        TOKEN_COUNT=0
     ):
     """Generate the json configuration for the readout and DF process"""
 
@@ -329,7 +329,8 @@ def generate_trigemu(
         NUMBER_OF_DATA_PRODUCERS=2,          
         DATA_RATE_SLOWDOWN_FACTOR = 1,
         RUN_NUMBER = 333, 
-        TRIGGER_RATE_HZ = 1.0
+        TRIGGER_RATE_HZ = 1.0,
+        TOKEN_COUNT = 10
     ):
     """Generate the json config for the TriggerDecisionEmulator process"""
     
@@ -412,7 +413,8 @@ def generate_trigemu(
                         # emitted per (wall-clock) second, rather than being
                         # spaced out further
                         trigger_interval_ticks=trg_interval_ticks,
-                        clock_frequency_hz=CLOCK_SPEED_HZ/DATA_RATE_SLOWDOWN_FACTOR                    
+                        clock_frequency_hz=CLOCK_SPEED_HZ/DATA_RATE_SLOWDOWN_FACTOR,
+                        initial_token_count=TOKEN_COUNT                    
                         )),
             ])
 
@@ -484,6 +486,13 @@ if __name__ == '__main__':
         else:
             json_file_df=json_file_base+"-ruemu_df-"
 
+        if token_count > 0:
+            df_token_count = 0
+            trigemu_token_count = token_count
+        else:
+            df_token_count = -1 * token_count
+            trigemu_token_count = 0
+
         network_endpoints={
             "trigdec" : f"tcp://{host_ip_trigemu}:12345",
             "triginh" : f"tcp://{host_ip_df}:12346",
@@ -498,7 +507,8 @@ if __name__ == '__main__':
                         NUMBER_OF_DATA_PRODUCERS = number_of_data_producers,
                         DATA_RATE_SLOWDOWN_FACTOR = data_rate_slowdown_factor,
                         RUN_NUMBER = run_number, 
-                        TRIGGER_RATE_HZ = trigger_rate_hz
+                        TRIGGER_RATE_HZ = trigger_rate_hz,
+                        TOKEN_COUNT = trigemu_token_count
                     ))
 
             with open(json_file_df+cmdname_seq[i]+".json", 'w') as f:
@@ -513,7 +523,7 @@ if __name__ == '__main__':
                         OUTPUT_PATH = output_path,
                         DISABLE_OUTPUT = disable_data_storage,
                         FLX_INPUT = use_felix,
-                        TOKEN_COUNT = token_count
+                        TOKEN_COUNT = df_token_count
                     ))
 
     cli()


### PR DESCRIPTION
TOKEN_COUNT as before, with the following change: negative token count
values indicate token-based operation, and the initial_token_count is
set for the DataWriter to -1 * count. TDE is set to 0. Positive values
result in DataWriter set to 0 and TDE set to count specified.