### PR TITLE
scalable queue size wrt link numbers

### DIFF
--- a/python/minidaqapp/fake_app_confgen.py
+++ b/python/minidaqapp/fake_app_confgen.py
@@ -61,7 +61,7 @@ def generate(
             app.QueueSpec(inst="trigger_decision_q", kind='FollySPSCQueue', capacity=20),
             app.QueueSpec(inst="trigger_decision_copy_for_bookkeeping", kind='FollySPSCQueue', capacity=20),
             app.QueueSpec(inst="trigger_record_q", kind='FollySPSCQueue', capacity=20),
-            app.QueueSpec(inst="data_fragments_q", kind='FollyMPMCQueue', capacity=100),
+            app.QueueSpec(inst="data_fragments_q", kind='FollyMPMCQueue', capacity=20*NUMBER_OF_DATA_PRODUCERS),
         ] + [
             app.QueueSpec(inst=f"data_requests_{idx}", kind='FollySPSCQueue', capacity=20)
                 for idx in range(NUMBER_OF_DATA_PRODUCERS)

--- a/python/minidaqapp/nanorc/rudf_gen.py
+++ b/python/minidaqapp/nanorc/rudf_gen.py
@@ -108,7 +108,7 @@ def generate(
             app.QueueSpec(inst="trigger_decision_from_netq", kind='FollySPSCQueue', capacity=100),
             app.QueueSpec(inst="trigger_decision_copy_for_bookkeeping", kind='FollySPSCQueue', capacity=100),
             app.QueueSpec(inst="trigger_record_q", kind='FollySPSCQueue', capacity=100),
-            app.QueueSpec(inst="data_fragments_q", kind='FollyMPMCQueue', capacity=1000),
+            app.QueueSpec(inst="data_fragments_q", kind='FollyMPMCQueue', capacity=100*NUMBER_OF_DATA_PRODUCERS),
         ] + [
             app.QueueSpec(inst=f"data_requests_{idx}", kind='FollySPSCQueue', capacity=100)
                 for idx in range(NUMBER_OF_DATA_PRODUCERS)


### PR DESCRIPTION
This pull request extends the MPMC queue as a function of the number of links. I don't know if we have to do the same trick with the queue for the time sync. Feedback and opinions are welcome here especially before merging. 
I tested this configuration and indeed it makes things stable at 50 Hz :-) 