### PR TITLE
Kbiery/reduce fragment loss at stop

### DIFF
--- a/python/minidaqapp/nanorc/mdapp_multiru_gen.py
+++ b/python/minidaqapp/nanorc/mdapp_multiru_gen.py
@@ -148,7 +148,7 @@ def cli(number_of_data_producers, emulator_mode, data_rate_slowdown_factor, run_
 
 
     console.log(f"Generating top-level command json files")
-    start_order = app_ru + [app_df, app_trgemu]
+    start_order = [app_df] + app_ru + [app_trgemu]
     for c in cmd_set:
         with open(join(json_dir,f'{c}.json'), 'w') as f:
             cfg = {


### PR DESCRIPTION
In certain stressful conditions (e.g. 10 links, no slowdown factor, moderately powerful computer), I see occasional missing Fragments at the end of a run when testing a 1-process and a 3-process system. (The 3-process system is RU, DF, and TRG.)  These tests use the FakeCardReader.

I found that using a different order for Stop commands to the 3 processes resulted in fewer missing fragments.