### PR TITLE
Floriangroetschla/data recorder integration

### DIFF
--- a/python/minidaqapp/fake_app_confgen.py
+++ b/python/minidaqapp/fake_app_confgen.py
@@ -3,6 +3,8 @@ from dunedaq.env import get_moo_model_path
 import moo.io
 moo.io.default_load_path = get_moo_model_path()
 
+from os.path import join
+
 # Load configuration types
 import moo.otypes
 
@@ -51,7 +53,10 @@ def generate(
         DATA_FILE="./frames.bin",
         OUTPUT_PATH=".",
         DISABLE_OUTPUT=False,
-        TOKEN_COUNT=10
+        TOKEN_COUNT=10,
+        RAW_RECORDING_ENABLED = False,
+        RAW_RECORDING_OUTPUT_DIR = ".",
+        RAW_RECORDING_DURATION = 1
     ):
     
     trigger_interval_ticks = math.floor((1/TRIGGER_RATE_HZ) * CLOCK_SPEED_HZ/DATA_RATE_SLOWDOWN_FACTOR)
@@ -71,11 +76,13 @@ def generate(
 
             app.QueueSpec(inst=f"wib_fake_link_{idx}", kind='FollySPSCQueue', capacity=100000)
                 for idx in range(NUMBER_OF_DATA_PRODUCERS)
-        ] + [
-            app.QueueSpec(inst=f"snb_link_{idx}", kind='FollySPSCQueue', capacity=100000)
-                for idx in range(NUMBER_OF_DATA_PRODUCERS)
         ]
-    
+
+    if (RAW_RECORDING_ENABLED):
+        queue_bare_specs = queue_bare_specs + [
+            app.QueueSpec(inst=f"raw_recording_link_{idx}", kind='FollySPSCQueue', capacity=100000)
+            for idx in range(NUMBER_OF_DATA_PRODUCERS)
+        ]
 
     # Only needed to reproduce the same order as when using jsonnet
     queue_specs = app.QueueSpecs(sorted(queue_bare_specs, key=lambda x: x.inst))
@@ -113,21 +120,31 @@ def generate(
                             for idx in range(NUMBER_OF_DATA_PRODUCERS)
                         ]),
 
+        ]
+
+    if (RAW_RECORDING_ENABLED):
+        mod_specs = mod_specs + [
+            mspec(f"datahandler_{idx}", "DataLinkHandler", [
+                app.QueueInfo(name="raw_input", inst=f"wib_fake_link_{idx}", dir="input"),
+                app.QueueInfo(name="timesync", inst="time_sync_q", dir="output"),
+                app.QueueInfo(name="requests", inst=f"data_requests_{idx}", dir="input"),
+                app.QueueInfo(name="fragments", inst="data_fragments_q", dir="output"),
+                app.QueueInfo(name="snb", inst=f"raw_recording_link_{idx}", dir="output")
+            ]) for idx in range(NUMBER_OF_DATA_PRODUCERS)
         ] + [
-                mspec(f"datahandler_{idx}", "DataLinkHandler", [
-
-                            app.QueueInfo(name="raw_input", inst=f"wib_fake_link_{idx}", dir="input"),
-                            app.QueueInfo(name="timesync", inst="time_sync_q", dir="output"),
-                            app.QueueInfo(name="requests", inst=f"data_requests_{idx}", dir="input"),
-                            app.QueueInfo(name="fragments", inst="data_fragments_q", dir="output"),
-                            app.QueueInfo(name="snb", inst=f"snb_link_{idx}", dir="output"),
-                            ]) for idx in range(NUMBER_OF_DATA_PRODUCERS)
-        ]  + [
-                mspec(f"data_recorder_{idx}", "DataRecorder", [
-
-                            app.QueueInfo(name="snb", inst=f"snb_link_{idx}", dir="input")
-                            ]) for idx in range(NUMBER_OF_DATA_PRODUCERS)
-    ]
+            mspec(f"data_recorder_{idx}", "DataRecorder", [
+                app.QueueInfo(name="snb", inst=f"raw_recording_link_{idx}", dir="input")
+            ]) for idx in range(NUMBER_OF_DATA_PRODUCERS)
+        ]
+    else:
+        mod_specs = mod_specs + [
+            mspec(f"datahandler_{idx}", "DataLinkHandler", [
+                app.QueueInfo(name="raw_input", inst=f"wib_fake_link_{idx}", dir="input"),
+                app.QueueInfo(name="timesync", inst="time_sync_q", dir="output"),
+                app.QueueInfo(name="requests", inst=f"data_requests_{idx}", dir="input"),
+                app.QueueInfo(name="fragments", inst="data_fragments_q", dir="output")
+            ]) for idx in range(NUMBER_OF_DATA_PRODUCERS)
+        ]
 
     init_specs = app.Init(queues=queue_specs, modules=mod_specs)
 
@@ -218,10 +235,10 @@ def generate(
                         )) for idx in range(NUMBER_OF_DATA_PRODUCERS)
             ] + [
                 (f"data_recorder_{idx}", dr.Conf(
-                        output_file = f"output_{idx}.out",
+                        output_file = join(RAW_RECORDING_OUTPUT_DIR, f"output_{idx}.out"),
                         compression_algorithm = "None",
                         stream_buffer_size = 8388608
-                        )) for idx in range(NUMBER_OF_DATA_PRODUCERS)
+                        )) for idx in (range(NUMBER_OF_DATA_PRODUCERS) if RAW_RECORDING_ENABLED else [])
     ])
     
     jstr = json.dumps(confcmd.pod(), indent=4, sort_keys=True)
@@ -278,17 +295,21 @@ def generate(
     jstr = json.dumps(scrapcmd.pod(), indent=4, sort_keys=True)
     print("="*80+"\nScrap\n\n", jstr)
 
-    recordcmd = mrccmd("record", "RUNNING", "RUNNING", [
-        ("datahandler_.*", dlh.RecordingParams(
-            duration=10
-        ))
-    ])
-
-    jstr = json.dumps(recordcmd.pod(), indent=4, sort_keys=True)
-    print("="*80+"\nRecord\n\n", jstr)
-
     # Create a list of commands
-    cmd_seq = [initcmd, confcmd, startcmd, stopcmd, pausecmd, resumecmd, scrapcmd, recordcmd]
+    cmd_seq = [initcmd, confcmd, startcmd, stopcmd, pausecmd, resumecmd, scrapcmd]
+
+    if (RAW_RECORDING_ENABLED):
+        # Add optional command
+        record_cmd = mrccmd("record", "RUNNING", "RUNNING", [
+            ("datahandler_.*", dlh.RecordingParams(
+                duration=RAW_RECORDING_DURATION
+            ))
+        ])
+
+        jstr = json.dumps(record_cmd.pod(), indent=4, sort_keys=True)
+        print("="*80+"\nRecord\n\n", jstr)
+
+        cmd_seq.append(record_cmd)
 
     # Print them as json (to be improved/moved out)
     jstr = json.dumps([c.pod() for c in cmd_seq], indent=4, sort_keys=True)
@@ -310,8 +331,11 @@ if __name__ == '__main__':
     @click.option('-o', '--output-path', type=click.Path(), default='.')
     @click.option('--disable-data-storage', is_flag=True)
     @click.option('-c', '--token-count', default=10)
+    @click.option('--enable-raw-recording', is_flag=True)
+    @click.option('--raw-recording-output-dir', type=click.Path(), default='.')
+    @click.option('--raw-recording-duration', default=1)
     @click.argument('json_file', type=click.Path(), default='minidaq-app-fake-readout.json')
-    def cli(number_of_data_producers, emulator_mode, data_rate_slowdown_factor, run_number, trigger_rate_hz, data_file, output_path, disable_data_storage, token_count, json_file):
+    def cli(number_of_data_producers, emulator_mode, data_rate_slowdown_factor, run_number, trigger_rate_hz, data_file, output_path, disable_data_storage, token_count, enable_raw_recording, raw_recording_output_dir, raw_recording_duration, json_file):
         """
           JSON_FILE: Input raw data file.
           JSON_FILE: Output json configuration file.
@@ -327,7 +351,10 @@ if __name__ == '__main__':
                     DATA_FILE = data_file,
                     OUTPUT_PATH = output_path,
                     DISABLE_OUTPUT = disable_data_storage,
-                    TOKEN_COUNT = token_count
+                    TOKEN_COUNT = token_count,
+                    RAW_RECORDING_ENABLED = enable_raw_recording,
+                    RAW_RECORDING_OUTPUT_DIR = raw_recording_output_dir,
+                    RAW_RECORDING_DURATION = raw_recording_duration
                 ))
 
         print(f"'{json_file}' generation completed.")

--- a/python/minidaqapp/fake_app_confgen.py
+++ b/python/minidaqapp/fake_app_confgen.py
@@ -121,11 +121,11 @@ def generate(
                 app.QueueInfo(name="timesync", inst="time_sync_q", dir="output"),
                 app.QueueInfo(name="requests", inst=f"data_requests_{idx}", dir="input"),
                 app.QueueInfo(name="fragments", inst="data_fragments_q", dir="output"),
-                app.QueueInfo(name="snb", inst=f"raw_recording_link_{idx}", dir="output")
+                app.QueueInfo(name="raw_recording", inst=f"raw_recording_link_{idx}", dir="output")
             ]) for idx in range(NUMBER_OF_DATA_PRODUCERS)
         ] + [
             mspec(f"data_recorder_{idx}", "DataRecorder", [
-                app.QueueInfo(name="snb", inst=f"raw_recording_link_{idx}", dir="input")
+                app.QueueInfo(name="raw_recording", inst=f"raw_recording_link_{idx}", dir="input")
             ]) for idx in range(NUMBER_OF_DATA_PRODUCERS)
         ]
     else:

--- a/python/minidaqapp/fake_app_confgen.py
+++ b/python/minidaqapp/fake_app_confgen.py
@@ -17,6 +17,7 @@ moo.otypes.load_types('dfmodules/datawriter.jsonnet')
 moo.otypes.load_types('dfmodules/hdf5datastore.jsonnet')
 moo.otypes.load_types('readout/fakecardreader.jsonnet')
 moo.otypes.load_types('readout/datalinkhandler.jsonnet')
+moo.otypes.load_types('readout/datarecorder.jsonnet')
 
 # Import new types
 import dunedaq.cmdlib.cmd as basecmd # AddressedCmd, 
@@ -30,6 +31,7 @@ import dunedaq.dfmodules.datawriter as dw
 import dunedaq.dfmodules.hdf5datastore as hdf5ds
 import dunedaq.readout.fakecardreader as fcr
 import dunedaq.readout.datalinkhandler as dlh
+import dunedaq.readout.datarecorder as dr
 
 from appfwk.utils import mcmd, mrccmd, mspec
 
@@ -68,6 +70,9 @@ def generate(
         ] + [
 
             app.QueueSpec(inst=f"wib_fake_link_{idx}", kind='FollySPSCQueue', capacity=100000)
+                for idx in range(NUMBER_OF_DATA_PRODUCERS)
+        ] + [
+            app.QueueSpec(inst=f"snb_link_{idx}", kind='FollySPSCQueue', capacity=100000)
                 for idx in range(NUMBER_OF_DATA_PRODUCERS)
         ]
     
@@ -115,8 +120,14 @@ def generate(
                             app.QueueInfo(name="timesync", inst="time_sync_q", dir="output"),
                             app.QueueInfo(name="requests", inst=f"data_requests_{idx}", dir="input"),
                             app.QueueInfo(name="fragments", inst="data_fragments_q", dir="output"),
+                            app.QueueInfo(name="snb", inst=f"snb_link_{idx}", dir="output"),
                             ]) for idx in range(NUMBER_OF_DATA_PRODUCERS)
-        ]
+        ]  + [
+                mspec(f"data_recorder_{idx}", "DataRecorder", [
+
+                            app.QueueInfo(name="snb", inst=f"snb_link_{idx}", dir="input")
+                            ]) for idx in range(NUMBER_OF_DATA_PRODUCERS)
+    ]
 
     init_specs = app.Init(queues=queue_specs, modules=mod_specs)
 
@@ -205,7 +216,13 @@ def generate(
                         apa_number = 0,
                         link_number = idx
                         )) for idx in range(NUMBER_OF_DATA_PRODUCERS)
-            ])
+            ] + [
+                (f"data_recorder_{idx}", dr.Conf(
+                        output_file = f"output_{idx}.out",
+                        compression_algorithm = "None",
+                        stream_buffer_size = 8388608
+                        )) for idx in range(NUMBER_OF_DATA_PRODUCERS)
+    ])
     
     jstr = json.dumps(confcmd.pod(), indent=4, sort_keys=True)
     print(jstr)
@@ -215,6 +232,7 @@ def generate(
             ("datawriter", startpars),
             ("ffr", startpars),
             ("datahandler_.*", startpars),
+            ("data_recorder_.*", startpars),
             ("fake_source", startpars),
             ("rqg", startpars),
             ("tde", startpars),
@@ -229,6 +247,7 @@ def generate(
             ("rqg", None),
             ("fake_source", None),
             ("datahandler_.*", None),
+            ("datarecorder_.*", None),
             ("ffr", None),
             ("datawriter", None),
         ])
@@ -259,8 +278,17 @@ def generate(
     jstr = json.dumps(scrapcmd.pod(), indent=4, sort_keys=True)
     print("="*80+"\nScrap\n\n", jstr)
 
+    recordcmd = mrccmd("record", "RUNNING", "RUNNING", [
+        ("datahandler_.*", dlh.RecordingParams(
+            duration=10
+        ))
+    ])
+
+    jstr = json.dumps(recordcmd.pod(), indent=4, sort_keys=True)
+    print("="*80+"\nRecord\n\n", jstr)
+
     # Create a list of commands
-    cmd_seq = [initcmd, confcmd, startcmd, stopcmd, pausecmd, resumecmd, scrapcmd]
+    cmd_seq = [initcmd, confcmd, startcmd, stopcmd, pausecmd, resumecmd, scrapcmd, recordcmd]
 
     # Print them as json (to be improved/moved out)
     jstr = json.dumps([c.pod() for c in cmd_seq], indent=4, sort_keys=True)

--- a/python/minidaqapp/flx_app_confgen.py
+++ b/python/minidaqapp/flx_app_confgen.py
@@ -122,7 +122,7 @@ def generate(
     if (RAW_RECORDING_ENABLED):
         mod_specs = mod_specs + [
             mspec(f"datahandler_{idx}", "DataLinkHandler", [
-                app.QueueInfo(name="raw_input", inst=f"wib_fake_link_{idx}", dir="input"),
+                app.QueueInfo(name="raw_input", inst=f"wib_link_{idx}", dir="input"),
                 app.QueueInfo(name="timesync", inst="time_sync_q", dir="output"),
                 app.QueueInfo(name="requests", inst=f"data_requests_{idx}", dir="input"),
                 app.QueueInfo(name="fragments", inst="data_fragments_q", dir="output"),

--- a/python/minidaqapp/flx_app_confgen.py
+++ b/python/minidaqapp/flx_app_confgen.py
@@ -3,6 +3,8 @@ from dunedaq.env import get_moo_model_path
 import moo.io
 moo.io.default_load_path = get_moo_model_path()
 
+from os.path import join
+
 # Load configuration types
 import moo.otypes
 
@@ -49,7 +51,10 @@ def generate(
         TRIGGER_RATE_HZ = 1.0,
         OUTPUT_PATH=".",
         DISABLE_OUTPUT=False,
-        TOKEN_COUNT=10
+        TOKEN_COUNT=10,
+        RAW_RECORDING_ENABLED = False,
+        RAW_RECORDING_OUTPUT_DIR = ".",
+        RAW_RECORDING_DURATION = 1
     ):
     
     trigger_interval_ticks = math.floor((1/TRIGGER_RATE_HZ) * CLOCK_SPEED_HZ)
@@ -69,9 +74,12 @@ def generate(
 
             app.QueueSpec(inst=f"wib_link_{idx}", kind='FollySPSCQueue', capacity=100000)
                 for idx in range(NUMBER_OF_DATA_PRODUCERS)
-        ] + [
-            app.QueueSpec(inst=f"snb_link_{idx}", kind='FollySPSCQueue', capacity=100000)
-                for idx in range(NUMBER_OF_DATA_PRODUCERS)
+        ]
+
+    if (RAW_RECORDING_ENABLED):
+        queue_bare_specs = queue_bare_specs + [
+            app.QueueSpec(inst=f"raw_recording_link_{idx}", kind='FollySPSCQueue', capacity=100000)
+            for idx in range(NUMBER_OF_DATA_PRODUCERS)
         ]
     
 
@@ -109,21 +117,31 @@ def generate(
                             for idx in range(min(5,NUMBER_OF_DATA_PRODUCERS))
                         ]),
 
-        ] + [
-                mspec(f"datahandler_{idx}", "DataLinkHandler", [
+        ]
 
-                            app.QueueInfo(name="raw_input", inst=f"wib_link_{idx}", dir="input"),
-                            app.QueueInfo(name="timesync", inst="time_sync_q", dir="output"),
-                            app.QueueInfo(name="requests", inst=f"data_requests_{idx}", dir="input"),
-                            app.QueueInfo(name="fragments", inst="data_fragments_q", dir="output"),
-                            app.QueueInfo(name="snb", inst=f"snb_link_{idx}", dir="output"),
-                            ]) for idx in range(NUMBER_OF_DATA_PRODUCERS)
+    if (RAW_RECORDING_ENABLED):
+        mod_specs = mod_specs + [
+            mspec(f"datahandler_{idx}", "DataLinkHandler", [
+                app.QueueInfo(name="raw_input", inst=f"wib_fake_link_{idx}", dir="input"),
+                app.QueueInfo(name="timesync", inst="time_sync_q", dir="output"),
+                app.QueueInfo(name="requests", inst=f"data_requests_{idx}", dir="input"),
+                app.QueueInfo(name="fragments", inst="data_fragments_q", dir="output"),
+                app.QueueInfo(name="snb", inst=f"raw_recording_link_{idx}", dir="output")
+            ]) for idx in range(NUMBER_OF_DATA_PRODUCERS)
         ] + [
-                mspec(f"data_recorder_{idx}", "DataRecorder", [
-
-                            app.QueueInfo(name="snb", inst=f"snb_link_{idx}", dir="input")
-                            ]) for idx in range(NUMBER_OF_DATA_PRODUCERS)
-    ]
+            mspec(f"data_recorder_{idx}", "DataRecorder", [
+                app.QueueInfo(name="snb", inst=f"raw_recording_link_{idx}", dir="input")
+            ]) for idx in range(NUMBER_OF_DATA_PRODUCERS)
+        ]
+    else:
+        mod_specs = mod_specs + [
+            mspec(f"datahandler_{idx}", "DataLinkHandler", [
+                app.QueueInfo(name="raw_input", inst=f"wib_fake_link_{idx}", dir="input"),
+                app.QueueInfo(name="timesync", inst="time_sync_q", dir="output"),
+                app.QueueInfo(name="requests", inst=f"data_requests_{idx}", dir="input"),
+                app.QueueInfo(name="fragments", inst="data_fragments_q", dir="output")
+            ]) for idx in range(NUMBER_OF_DATA_PRODUCERS)
+        ]
 
     if NUMBER_OF_DATA_PRODUCERS>5 :
         mod_specs.append(mspec("flxcard_1", "FelixCardReader", [
@@ -231,6 +249,12 @@ def generate(
                         compression_algorithm = "None",
                         stream_buffer_size = 8388608
                         )) for idx in range(NUMBER_OF_DATA_PRODUCERS)
+            ] + [
+                (f"data_recorder_{idx}", dr.Conf(
+                        output_file = join(RAW_RECORDING_OUTPUT_DIR, f"output_{idx}.out"),
+                        compression_algorithm = "None",
+                        stream_buffer_size = 8388608
+                        )) for idx in (range(NUMBER_OF_DATA_PRODUCERS) if RAW_RECORDING_ENABLED else [])
     ])
     
     jstr = json.dumps(confcmd.pod(), indent=4, sort_keys=True)
@@ -286,17 +310,21 @@ def generate(
     jstr = json.dumps(scrapcmd.pod(), indent=4, sort_keys=True)
     print("="*80+"\nScrap\n\n", jstr)
 
-    recordcmd = mrccmd("record", "RUNNING", "RUNNING", [
-        ("datahandler_.*", dlh.RecordingParams(
-            duration=10
-        ))
-    ])
-
-    jstr = json.dumps(recordcmd.pod(), indent=4, sort_keys=True)
-    print("="*80+"\nRecord\n\n", jstr)
-
     # Create a list of commands
-    cmd_seq = [initcmd, confcmd, startcmd, stopcmd, pausecmd, resumecmd, scrapcmd, recordcmd]
+    cmd_seq = [initcmd, confcmd, startcmd, stopcmd, pausecmd, resumecmd, scrapcmd]
+
+    if (RAW_RECORDING_ENABLED):
+        # Add optional command
+        record_cmd = mrccmd("record", "RUNNING", "RUNNING", [
+            ("datahandler_.*", dlh.RecordingParams(
+                duration=RAW_RECORDING_DURATION
+            ))
+        ])
+
+        jstr = json.dumps(record_cmd.pod(), indent=4, sort_keys=True)
+        print("="*80+"\nRecord\n\n", jstr)
+
+        cmd_seq.append(record_cmd)
 
     # Print them as json (to be improved/moved out)
     jstr = json.dumps([c.pod() for c in cmd_seq], indent=4, sort_keys=True)
@@ -316,8 +344,11 @@ if __name__ == '__main__':
     @click.option('-o', '--output-path', type=click.Path(), default='.')
     @click.option('--disable-data-storage', is_flag=True)
     @click.option('-c', '--token-count', default=10)
+    @click.option('--enable-raw-recording', is_flag=True)
+    @click.option('--raw-recording-output-dir', type=click.Path(), default='.')
+    @click.option('--raw-recording-duration', default=1)
     @click.argument('json_file', type=click.Path(), default='minidaq-app-felix-readout.json')
-    def cli(number_of_data_producers, emulator_mode, run_number, trigger_rate_hz, output_path, disable_data_storage, token_count, json_file):
+    def cli(number_of_data_producers, emulator_mode, run_number, trigger_rate_hz, output_path, disable_data_storage, token_count, enable_raw_recording, raw_recording_output_dir, raw_recording_duration, json_file):
         """
           JSON_FILE: Input raw data file.
           JSON_FILE: Output json configuration file.
@@ -331,7 +362,10 @@ if __name__ == '__main__':
                     TRIGGER_RATE_HZ = trigger_rate_hz,
                     OUTPUT_PATH = output_path,
                     DISABLE_OUTPUT = disable_data_storage,
-                    TOKEN_COUNT = token_count
+                    TOKEN_COUNT = token_count,
+                    RAW_RECORDING_ENABLED = enable_raw_recording,
+                    RAW_RECORDING_OUTPUT_DIR = raw_recording_output_dir,
+                    RAW_RECORDING_DURATION = raw_recording_duration
                 ))
 
         print(f"'{json_file}' generation completed.")

--- a/python/minidaqapp/flx_app_confgen.py
+++ b/python/minidaqapp/flx_app_confgen.py
@@ -245,12 +245,6 @@ def generate(
                         )) for idx in range(NUMBER_OF_DATA_PRODUCERS)
             ] + [
                 (f"data_recorder_{idx}", dr.Conf(
-                        output_file = f"output_{idx}.out",
-                        compression_algorithm = "None",
-                        stream_buffer_size = 8388608
-                        )) for idx in range(NUMBER_OF_DATA_PRODUCERS)
-            ] + [
-                (f"data_recorder_{idx}", dr.Conf(
                         output_file = join(RAW_RECORDING_OUTPUT_DIR, f"output_{idx}.out"),
                         compression_algorithm = "None",
                         stream_buffer_size = 8388608

--- a/python/minidaqapp/flx_app_confgen.py
+++ b/python/minidaqapp/flx_app_confgen.py
@@ -136,7 +136,7 @@ def generate(
     else:
         mod_specs = mod_specs + [
             mspec(f"datahandler_{idx}", "DataLinkHandler", [
-                app.QueueInfo(name="raw_input", inst=f"wib_fake_link_{idx}", dir="input"),
+                app.QueueInfo(name="raw_input", inst=f"wib_link_{idx}", dir="input"),
                 app.QueueInfo(name="timesync", inst="time_sync_q", dir="output"),
                 app.QueueInfo(name="requests", inst=f"data_requests_{idx}", dir="input"),
                 app.QueueInfo(name="fragments", inst="data_fragments_q", dir="output")

--- a/python/minidaqapp/flx_app_confgen.py
+++ b/python/minidaqapp/flx_app_confgen.py
@@ -126,11 +126,11 @@ def generate(
                 app.QueueInfo(name="timesync", inst="time_sync_q", dir="output"),
                 app.QueueInfo(name="requests", inst=f"data_requests_{idx}", dir="input"),
                 app.QueueInfo(name="fragments", inst="data_fragments_q", dir="output"),
-                app.QueueInfo(name="snb", inst=f"raw_recording_link_{idx}", dir="output")
+                app.QueueInfo(name="raw_recording", inst=f"raw_recording_link_{idx}", dir="output")
             ]) for idx in range(NUMBER_OF_DATA_PRODUCERS)
         ] + [
             mspec(f"data_recorder_{idx}", "DataRecorder", [
-                app.QueueInfo(name="snb", inst=f"raw_recording_link_{idx}", dir="input")
+                app.QueueInfo(name="raw_recording", inst=f"raw_recording_link_{idx}", dir="input")
             ]) for idx in range(NUMBER_OF_DATA_PRODUCERS)
         ]
     else:

--- a/python/minidaqapp/nanorc/dataflow_gen.py
+++ b/python/minidaqapp/nanorc/dataflow_gen.py
@@ -202,4 +202,6 @@ def generate(NETWORK_ENDPOINTS,
 
     cmd_data['scrap'] = acmd([("", None)])
 
+    cmd_data['record'] = acmd([("", None)])
+
     return cmd_data

--- a/python/minidaqapp/nanorc/mdapp_gen.py
+++ b/python/minidaqapp/nanorc/mdapp_gen.py
@@ -170,7 +170,7 @@ def cli(number_of_data_producers, emulator_mode, data_rate_slowdown_factor, run_
     jf_trigemu = join(data_dir, app_trgemu)
     jf_dfru = join(data_dir, app_rudf)
 
-    cmd_set = ["init", "conf", "start", "stop", "pause", "resume", "scrap"]
+    cmd_set = ["init", "conf", "start", "stop", "pause", "resume", "scrap", "record"]
     for app,data in ((app_trgemu, cmd_data_trg), (app_rudf, cmd_data_rudf)):
         console.log(f"Generating {app} command data json files")
         for c in cmd_set:

--- a/python/minidaqapp/nanorc/mdapp_gen.py
+++ b/python/minidaqapp/nanorc/mdapp_gen.py
@@ -105,8 +105,10 @@ import click
 @click.option('-f', '--use-felix', is_flag=True)
 @click.option('--host-rudf', default='localhost')
 @click.option('--host-trgemu', default='localhost')
+@click.option('--enable-raw-recording', is_flag=True)
+@click.option('--raw-recording-output-dir', type=click.Path(), default='.')
 @click.argument('json_dir', type=click.Path())
-def cli(number_of_data_producers, emulator_mode, data_rate_slowdown_factor, run_number, trigger_rate_hz, token_count, data_file, output_path, use_felix, host_rudf, host_trgemu, json_dir):
+def cli(number_of_data_producers, emulator_mode, data_rate_slowdown_factor, run_number, trigger_rate_hz, token_count, data_file, output_path, use_felix, host_rudf, host_trgemu, enable_raw_recording, raw_recording_output_dir, json_dir):
     """
       JSON_DIR: Json file output folder
     """
@@ -153,7 +155,9 @@ def cli(number_of_data_producers, emulator_mode, data_rate_slowdown_factor, run_
         OUTPUT_PATH = output_path,
         FLX_INPUT = use_felix,
         TOKEN_COUNT = df_token_count,
-        CLOCK_SPEED_HZ = CLOCK_SPEED_HZ
+        CLOCK_SPEED_HZ = CLOCK_SPEED_HZ,
+        RAW_RECORDING_ENABLED = enable_raw_recording,
+        RAW_RECORDING_OUTPUT_DIR = raw_recording_output_dir
     )
     console.log("rudf cmd data:", cmd_data_rudf)
 

--- a/python/minidaqapp/nanorc/mdapp_multiru_gen.py
+++ b/python/minidaqapp/nanorc/mdapp_multiru_gen.py
@@ -137,7 +137,7 @@ def cli(number_of_data_producers, emulator_mode, data_rate_slowdown_factor, run_
     jf_df = join(data_dir, app_df)
     jf_ru = [join(data_dir, app_ru[idx]) for idx in range(len(host_ru))]
 
-    cmd_set = ["init", "conf", "start", "stop", "pause", "resume", "scrap"]
+    cmd_set = ["init", "conf", "start", "stop", "pause", "resume", "scrap", "record"]
     for app,data in [(app_trgemu, cmd_data_trg), (app_df, cmd_data_dataflow)] + list(zip(app_ru, cmd_data_readout)):
         console.log(f"Generating {app} command data json files")
         for c in cmd_set:

--- a/python/minidaqapp/nanorc/mdapp_multiru_gen.py
+++ b/python/minidaqapp/nanorc/mdapp_multiru_gen.py
@@ -30,8 +30,10 @@ import click
 @click.option('--host-df', default='localhost')
 @click.option('--host-ru', multiple=True, default=['localhost'], help="This option is repeatable, with each repetition adding an additional ru process.")
 @click.option('--host-trg', default='localhost')
+@click.option('--enable-raw-recording', is_flag=True)
+@click.option('--raw-recording-output-dir', type=click.Path(), default='.')
 @click.argument('json_dir', type=click.Path())
-def cli(number_of_data_producers, emulator_mode, data_rate_slowdown_factor, run_number, trigger_rate_hz, token_count, data_file, output_path, enable_trace, use_felix, host_df, host_ru, host_trg, json_dir):
+def cli(number_of_data_producers, emulator_mode, data_rate_slowdown_factor, run_number, trigger_rate_hz, token_count, data_file, output_path, enable_trace, use_felix, host_df, host_ru, host_trg, enable_raw_recording, raw_recording_output_dir, json_dir):
     """
       JSON_DIR: Json file output folder
     """
@@ -119,7 +121,9 @@ def cli(number_of_data_producers, emulator_mode, data_rate_slowdown_factor, run_
             FLX_INPUT = use_felix,
             CLOCK_SPEED_HZ = CLOCK_SPEED_HZ,
             HOSTIDX = hostidx,
-            CARDID = cardid[hostidx]
+            CARDID = cardid[hostidx],
+            RAW_RECORDING_ENABLED = enable_raw_recording,
+            RAW_RECORDING_OUTPUT_DIR = raw_recording_output_dir
             ) for hostidx in range(len(host_ru))]
     console.log("readout cmd data:", cmd_data_readout)
 

--- a/python/minidaqapp/nanorc/readout_gen.py
+++ b/python/minidaqapp/nanorc/readout_gen.py
@@ -132,11 +132,11 @@ def generate(NETWORK_ENDPOINTS,
                 app.QueueInfo(name="timesync", inst="time_sync_q", dir="output"),
                 app.QueueInfo(name="requests", inst=f"data_requests_{idx}", dir="input"),
                 app.QueueInfo(name="fragments", inst="data_fragments_q", dir="output"),
-                app.QueueInfo(name="snb", inst=f"raw_recording_link_{idx}", dir="output")
+                app.QueueInfo(name="raw_recording", inst=f"raw_recording_link_{idx}", dir="output")
             ]) for idx in range(NUMBER_OF_DATA_PRODUCERS)
         ] + [
             mspec(f"data_recorder_{idx}", "DataRecorder", [
-                app.QueueInfo(name="snb", inst=f"raw_recording_link_{idx}", dir="input")
+                app.QueueInfo(name="raw_recording", inst=f"raw_recording_link_{idx}", dir="input")
             ]) for idx in range(NUMBER_OF_DATA_PRODUCERS)
         ]
     else:

--- a/python/minidaqapp/nanorc/readout_gen.py
+++ b/python/minidaqapp/nanorc/readout_gen.py
@@ -220,7 +220,7 @@ def generate(NETWORK_ENDPOINTS,
                         link_number = idx)) for idx in range(MIN_LINK,MAX_LINK)
             ] + [
                 (f"data_recorder_{idx}", dr.Conf(
-                        output_file = f"output_{idx}.out",
+                        output_file = f"output_{idx + MIN_LINK}.out",
                         compression_algorithm = "None",
                         stream_buffer_size = 8388608)) for idx in range(NUMBER_OF_DATA_PRODUCERS)
     ])

--- a/python/minidaqapp/nanorc/readout_gen.py
+++ b/python/minidaqapp/nanorc/readout_gen.py
@@ -127,10 +127,10 @@ def generate(NETWORK_ENDPOINTS,
 
     if RAW_RECORDING_ENABLED:
         mod_specs = mod_specs + [
-            mspec(f"datahandler_{idx}", "DataLinkHandler", [
+            mspec(f"datahandler_{idx + MIN_LINK}", "DataLinkHandler", [
                 app.QueueInfo(name="raw_input", inst=f"wib_link_{idx}", dir="input"),
                 app.QueueInfo(name="timesync", inst="time_sync_q", dir="output"),
-                app.QueueInfo(name="requests", inst=f"data_requests_{idx}", dir="input"),
+                app.QueueInfo(name="requests", inst=f"data_requests_{idx + MIN_LINK}", dir="input"),
                 app.QueueInfo(name="fragments", inst="data_fragments_q", dir="output"),
                 app.QueueInfo(name="raw_recording", inst=f"raw_recording_link_{idx}", dir="output")
             ]) for idx in range(NUMBER_OF_DATA_PRODUCERS)
@@ -141,10 +141,10 @@ def generate(NETWORK_ENDPOINTS,
         ]
     else:
         mod_specs = mod_specs + [
-            mspec(f"datahandler_{idx}", "DataLinkHandler", [
+            mspec(f"datahandler_{idx + MIN_LINK}", "DataLinkHandler", [
                 app.QueueInfo(name="raw_input", inst=f"wib_link_{idx}", dir="input"),
                 app.QueueInfo(name="timesync", inst="time_sync_q", dir="output"),
-                app.QueueInfo(name="requests", inst=f"data_requests_{idx}", dir="input"),
+                app.QueueInfo(name="requests", inst=f"data_requests_{idx + MIN_LINK}", dir="input"),
                 app.QueueInfo(name="fragments", inst="data_fragments_q", dir="output")
             ]) for idx in range(NUMBER_OF_DATA_PRODUCERS)
         ]

--- a/python/minidaqapp/nanorc/rudf_gen.py
+++ b/python/minidaqapp/nanorc/rudf_gen.py
@@ -168,11 +168,11 @@ def generate(
                 app.QueueInfo(name="timesync", inst="time_sync_q", dir="output"),
                 app.QueueInfo(name="requests", inst=f"data_requests_{idx}", dir="input"),
                 app.QueueInfo(name="fragments", inst="data_fragments_q", dir="output"),
-                app.QueueInfo(name="snb", inst=f"raw_recording_link_{idx}", dir="output")
+                app.QueueInfo(name="raw_recording", inst=f"raw_recording_link_{idx}", dir="output")
             ]) for idx in range(NUMBER_OF_DATA_PRODUCERS)
         ] + [
             mspec(f"data_recorder_{idx}", "DataRecorder", [
-                app.QueueInfo(name="snb", inst=f"raw_recording_link_{idx}", dir="input")
+                app.QueueInfo(name="raw_recording", inst=f"raw_recording_link_{idx}", dir="input")
             ]) for idx in range(NUMBER_OF_DATA_PRODUCERS)
         ]
     else:

--- a/python/minidaqapp/nanorc/trg_gen.py
+++ b/python/minidaqapp/nanorc/trg_gen.py
@@ -203,4 +203,8 @@ def generate(
             ("", None)
         ])
 
+    cmd_data['record'] = acmd([
+            ("", None)
+    ])
+
     return cmd_data

--- a/python/minidaqapp/nanorc/trigger_gen.py
+++ b/python/minidaqapp/nanorc/trigger_gen.py
@@ -175,4 +175,8 @@ def generate(
         ("", None)
     ])
 
+    cmd_data['record'] = acmd([
+        ("", None)
+    ])
+
     return cmd_data


### PR DESCRIPTION
Add an optional `record` command to all configurations. It starts the raw recording for a specified amount of time. For the non-nanorc configurations this time is set when creating the config. For the nanorc configurations this time will be set when running the command. The additional links and modules are only added when using `--enable-raw-recording`. For non-nanorc configurations the command is not added if the recording is not enabled. For nanorc some changes are necessary to add the new command. If `record` is called from nanorc on a configuration that does not have raw recording enabled the user will be notified that the recording could not be started in the debug output of the DLH.
A fork of nanorc with the addition of the `record` command (for testing) can be found in the repo [https://github.com/floriangroetschla/nanorc/tree/record_command](https://github.com/floriangroetschla/nanorc/tree/record_command) on the branch `record_command`.