### PR TITLE
Carloschavez/doc update

### DIFF
--- a/docs/ConfigurationsForCasualUsers.md
+++ b/docs/ConfigurationsForCasualUsers.md
@@ -27,11 +27,14 @@ The `Input` and `Output` data system options can be use in the follwing way
 
 `python -m minidaqapp.nanorc.mdapp_multiru_gen -d ./frames.bin -o .  mdapp_fake`
 
-3) The default trigger rate generated is of 1 Hz per readout unit (ru). This can be changed with the option `-t INTEGER`, for example run:
+3) The default trigger rate generated is of 1 Hz per readout unit (ru). This can be changed with the option `--trigger-rate-hz FLOAT` (default 1.0 Hz), or alternatively with the option `--hsi-event-period FLOAT` (default value 1e9, provides 1.0 Hz). For example to increase the trigger rate generated to 2.0 Hz, the user can run with either of these two options:
 
-`python -m minidaqapp.nanorc.mdapp_multiru_gen -d ./frames.bin -o . -t 2  mdapp_fake`
+`python -m minidaqapp.nanorc.mdapp_multiru_gen -d ./frames.bin -o . --trigger-rate-hz 2.0  mdapp_fake`
 
-4) Use option `-s INTEGER` to slow down the generated data rate by a factor of INTEGER, this could be particularly useful when the user is running the system on a slow computer that can't create data fast enough to match what the real electronics can do. For example to slow down the data produccion rate, run the following commmand:
+`python -m minidaqapp.nanorc.mdapp_multiru_gen -d ./frames.bin -o . --hsi-event-period 500000000.0 mdapp_fake`
+  
+
+4) Use option `-s INTEGER` to slow down the generated data rate by a factor of INTEGER, this is achieved by slowing down the simulated clock speed for generating data. This option is particularly useful when the user is running the system on a slow computer that can't create data fast enough to match what the real electronics can do. For example to slowdown the data produccion rate by a factor of 10, run the following commmand:
 
 `python -m minidaqapp.nanorc.mdapp_multiru_gen -d ./frames.bin -o . -s 10  mdapp_fake`
 

--- a/docs/ConfigurationsForCasualUsers.md
+++ b/docs/ConfigurationsForCasualUsers.md
@@ -22,8 +22,8 @@ The configurations can be run interactively with `nanorc mdapp_fake` from the `<
 1) In order to get the full set of configuration options and their `help` , run :  
 `python -m minidaqapp.nanorc.mdapp_multiru_gen -h`
 
-2) The data `Input` and `Output` system configuration options are as follow. Input data file `-d ./frames.bin` for input file `./frames.bin` containing data frames that are replayed by fake cards in the current system, as above, the input data file can be downloaded with "`curl -o frames.bin -O https://cernbox.cern.ch/index.php/s/VAqNtn7bwuQtff3/download`". The output data path option `-o` , can be used for example to specify the current directory, as in  `-o .` . These options allow the user to change the input data file and the output data directory path as the user see fit.  
-The `Input` and `Output` data system options can be use in the follwing way 
+2) The data `Input` and `Output` system configuration options allow the user to change the input data file location and the output data directory path as needed. To specify an input `frames.bin` file from the current directory, a user would use `-d ./frames.bin`. This file contains data frames that are replayed by fake cards in the current system, and as mentioned above, this file can be downloaded with "`curl -o frames.bin -O https://cernbox.cern.ch/index.php/s/VAqNtn7bwuQtff3/download`". The output data path option `-o` can be used to specify the directory where output data files are written.  To write the output data files to the current directory, one would use `-o .`
+The `Input` and `Output` data system options can be use in the following way 
 
 `python -m minidaqapp.nanorc.mdapp_multiru_gen -d ./frames.bin -o .  mdapp_fake`
 

--- a/docs/ConfigurationsForCasualUsers.md
+++ b/docs/ConfigurationsForCasualUsers.md
@@ -17,21 +17,21 @@ The tools to generate these configurations consist of a single Python script tha
 The config_gen files under `python/minidaqapp/nanorc` directory were developed to work with _nanorc_ package, which itself can be seen as a basic Finite State Machine that sends commands and drives the MiniDaq app.
 
 The created configurations will be called `mdapp_fake` and there will be a `mdapp_fake` directory created containing the produced configuration to be used with  _nanorc_.
-The configurations can be run interactively with `nanorc mdapp_fake` from the <work_dir>.
+The configurations can be run interactively with `nanorc mdapp_fake` from the `<work_dir>`.
 
 1) In order to get the full set of configuration options and their `help` , run :  
 `python -m minidaqapp.nanorc.mdapp_multiru_gen -h`
 
-2) default system configuration using input data file containing data frames to be replayed by fake cards, as downloaded above use option `-d ./frames.bin`,  and the output will be in the current directory `-o .` , run:
+2) The data `Input` and `Output` system configuration options are as follow. Input data file `-d ./frames.bin` for input file `./frames.bin` containing data frames that are replayed by fake cards in the current system, as above, the input data file can be downloaded with "`curl -o frames.bin -O https://cernbox.cern.ch/index.php/s/VAqNtn7bwuQtff3/download`". The output data path option `-o` , can be used for example to specify the current directory, as in  `-o .` . These options allow the user to change the input data file and the output data directory path as the user see fit.  
+The `Input` and `Output` data system options can be use in the follwing way 
 
 `python -m minidaqapp.nanorc.mdapp_multiru_gen -d ./frames.bin -o .  mdapp_fake`
-
 
 3) The default trigger rate generated is of 1 Hz per readout unit (ru). This can be changed with the option `-t INTEGER`, for example run:
 
 `python -m minidaqapp.nanorc.mdapp_multiru_gen -d ./frames.bin -o . -t 2  mdapp_fake`
 
-4) Use option `-s INTEGER` to slow down the generated data rate by a factor of INTEGER, for example run:
+4) Use option `-s INTEGER` to slow down the generated data rate by a factor of INTEGER, this could be particularly useful when the user is running the system on a slow computer that can't create data fast enough to match what the real electronics can do. For example to slow down the data produccion rate, run the following commmand:
 
 `python -m minidaqapp.nanorc.mdapp_multiru_gen -d ./frames.bin -o . -s 10  mdapp_fake`
 

--- a/docs/ConfigurationsForCasualUsers.md
+++ b/docs/ConfigurationsForCasualUsers.md
@@ -12,9 +12,9 @@ After you have setup the environment and downloaded the fake input data file
    or clicking on the [CERNBox link](https://cernbox.cern.ch/index.php/s/VAqNtn7bwuQtff3/download)) and put it into `<work_dir>`
 
 
-Now we generate some sample system configurations and use _[nanorc](https://dune-daq-sw.readthedocs.io/en/latest/packages/nanorc/)_ to run MiniDaq app with them.
+Now we generate some sample system configurations and use _[nanorc](https://dune-daq-sw.readthedocs.io/en/latest/packages/nanorc/)_ to run MiniDAQ app with them.
 The tools to generate these configurations consist of a single Python script that generates MiniDAQ system configurations with different characteristics based on command-line parameters that are given to the script. This script is minidaqapp/python/minidaqapp/nanorc/mdapp_multiru_gen.py. 
-The config_gen files under `python/minidaqapp/nanorc` directory were developed to work with _nanorc_ package, which itself can be seen as a basic Finite State Machine that sends commands and drives the MiniDaq app.
+The config_gen files under `python/minidaqapp/nanorc` directory were developed to work with _nanorc_ package, which itself can be seen as a basic Finite State Machine that sends commands and drives the MiniDAQ app.
 
 The created configurations will be called `mdapp_fake` and there will be a `mdapp_fake` directory created containing the produced configuration to be used with  _nanorc_.
 The configurations can be run interactively with `nanorc mdapp_fake` from the `<work_dir>`.
@@ -23,18 +23,18 @@ The configurations can be run interactively with `nanorc mdapp_fake` from the `<
 `python -m minidaqapp.nanorc.mdapp_multiru_gen -h`
 
 2) The data `Input` and `Output` system configuration options allow the user to change the input data file location and the output data directory path as needed. To specify an input `frames.bin` file from the current directory, a user would use `-d ./frames.bin`. This file contains data frames that are replayed by fake cards in the current system, and as mentioned above, this file can be downloaded with "`curl -o frames.bin -O https://cernbox.cern.ch/index.php/s/VAqNtn7bwuQtff3/download`". The output data path option `-o` can be used to specify the directory where output data files are written.  To write the output data files to the current directory, one would use `-o .`
-The `Input` and `Output` data system options can be use in the following way 
+The `Input` and `Output` data system options can be used in the following way 
 
 `python -m minidaqapp.nanorc.mdapp_multiru_gen -d ./frames.bin -o .  mdapp_fake`
 
-3) The default trigger rate generated is of 1 Hz per readout unit (ru). This can be changed with the option `--trigger-rate-hz FLOAT` (default 1.0 Hz), or alternatively with the option `--hsi-event-period FLOAT` (default value 1e9, provides 1.0 Hz). For example to increase the trigger rate generated to 2.0 Hz, the user can run with either of these two options:
+3) The default trigger rate generated is 1 Hz per readout unit (RU). This can be changed with the option `--trigger-rate-hz FLOAT` (default 1.0 Hz), or alternatively with the option `--hsi-event-period FLOAT` (default value 1e9, provides 1.0 Hz). For example to increase the trigger rate generated to 2.0 Hz, the user can run with either of these two options:
 
 `python -m minidaqapp.nanorc.mdapp_multiru_gen -d ./frames.bin -o . --trigger-rate-hz 2.0  mdapp_fake`
 
 `python -m minidaqapp.nanorc.mdapp_multiru_gen -d ./frames.bin -o . --hsi-event-period 500000000.0 mdapp_fake`
   
 
-4) Use option `-s INTEGER` to slow down the generated data rate by a factor of INTEGER, this is achieved by slowing down the simulated clock speed for generating data. This option is particularly useful when the user is running the system on a slow computer that can't create data fast enough to match what the real electronics can do. For example to slowdown the data produccion rate by a factor of 10, run the following commmand:
+4) Use option `-s INTEGER` to slow down the generated data rate by a factor of INTEGER, this is achieved by slowing down the simulated clock speed for generating data. This option is particularly useful when the user is running the system on a slow computer that can't create data fast enough to match what the real electronics can do. For example to slowdown the data production rate by a factor of 10, run the following commmand:
 
 `python -m minidaqapp.nanorc.mdapp_multiru_gen -d ./frames.bin -o . -s 10  mdapp_fake`
 
@@ -44,14 +44,15 @@ The `Input` and `Output` data system options can be use in the following way
 `python -m minidaqapp.nanorc.mdapp_multiru_gen -d ./frames.bin -o . -r 111  mdapp_fake`
 
 
-6) Use option `-n INTEGER` to specify the number of data producers (links) per ru (<10) or total, for example run :
+6) Use option `-n INTEGER` to specify the number of data producers (links) per RU (<10) or total. Since the maximum number of data producers per readout unit is 10, values for this parameter that are larger than 10 are interpreted to indicate the _total_ number of data producers instead of the number per RU. When the total number of data producers are specified, they are spread equally among the RUs, as much as possible.
+Here is an example command specifying 4 data producers (per RU) :
 
 `python -m minidaqapp.nanorc.mdapp_multiru_gen -d ./frames.bin -o . -n 4 mdapp_fake`
 
 
 7) Use options `--host-df TEXT` , `--host-ru TEXT` , `--host-trigger TEXT` , `--host-hsi TEXT`  to specify different hosts for the different applications (processes):
 `host Data-Flow (host-df)` 
-`host Readout Unit (host-ru)` this is a repeatable option adding an additional ru process each time
+`host Readout Unit (host-ru)` this is a repeatable option adding an additional RU process each time
 `host Trigger app  (host-trigger)`
 `host HSI app (--host-hsi)`
 
@@ -61,7 +62,7 @@ for example using the following fake IP addresses for the different hosts :  127
 
 the default for all the host options will be `localhost`
 
-8) Running _nanorc_ can be done in interactively or in batch mode, for the later you can specify a sequence of commands to drive MiniDaq app, for example run :
+8) Running _nanorc_ can be done in interactively or in batch mode, for the later you can specify a sequence of commands to drive MiniDAQ app, for example run :
 
  `nanorc mdapp_fake boot init conf start 102 wait 2 resume wait 60 pause wait 2 stop scrap terminate`
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,3 +10,5 @@ The focus of this documentation is on providing instructions for using the tools
 
 [Instructions for casual or first-time users](InstructionsForCasualUsers.md)
 
+[Configuration options for casual or first-time users](ConfigurationsForCasualUsers.md)
+

--- a/python/minidaqapp/nanorc/mdapp_multiru_gen.py
+++ b/python/minidaqapp/nanorc/mdapp_multiru_gen.py
@@ -21,7 +21,7 @@ import click
 @click.option('-e', '--emulator-mode', is_flag=True, help="If active, timestamps of data frames are overwritten when processed by the readout. This is necessary if the felix card does not set correct timestamps.")
 @click.option('-s', '--data-rate-slowdown-factor', default=1)
 @click.option('-r', '--run-number', default=333)
-@click.option('-t', '--trigger-rate-hz', default=1.0)
+@click.option('-t', '--trigger-rate-hz', default=1.0, help='Fake HSI only: rate at which fake HSIEvents are sent (this option provides an alternative way to specify the trigger rate compared to --hsi-event-period, however these two options should not be used together!)')
 @click.option('-c', '--token-count', default=10)
 @click.option('-d', '--data-file', type=click.Path(), default='./frames.bin', help="File containing data frames to be replayed by the fake cards")
 @click.option('-o', '--output-path', type=click.Path(), default='.')

--- a/python/minidaqapp/nanorc/mdapp_multiru_gen.py
+++ b/python/minidaqapp/nanorc/mdapp_multiru_gen.py
@@ -125,12 +125,14 @@ def cli(number_of_data_producers, emulator_mode, data_rate_slowdown_factor, run_
             HSI_DEVICE_NAME = hsi_device_name,
         )
     else:
+        #We use the option --trigger-rate-hz option (default=1) to devide hsi_event_period, this is our new HSI_EVENT_PERIOD_NS
+        hsi_event_period_rate_hz = math.floor((hsi_event_period/trigger_rate_hz)) 
         cmd_data_hsi = fake_hsi_gen.generate(
             network_endpoints,
             RUN_NUMBER = run_number,
             CLOCK_SPEED_HZ = CLOCK_SPEED_HZ,
             DATA_RATE_SLOWDOWN_FACTOR = data_rate_slowdown_factor,
-            HSI_EVENT_PERIOD_NS = hsi_event_period,
+            HSI_EVENT_PERIOD_NS = hsi_event_period_rate_hz,
             HSI_DEVICE_ID = hsi_device_id,
             MEAN_SIGNAL_MULTIPLICITY = mean_hsi_signal_multiplicity,
             SIGNAL_EMULATION_MODE = hsi_signal_emulation_mode,


### PR DESCRIPTION
Updates to the Documentation, in particular addressing the comments from Kurt about configuration options.

The option -t, --trigger-rate-hz FLOAT  was reintroduce in python/minidaqapp/nanorc/mdapp_multiru_gen.py 
The interplay with option --hsi-event-period  is  explicit as :   
hsi_event_period_rate_hz = math.floor((hsi_event_period/trigger_rate_hz))
So the documentation now says that the user should use EITHER of these options.


