### PR TITLE
Changes in readout configuration, integration with DQM

### DIFF
--- a/python/minidaqapp/nanorc/fake_hsi_gen.py
+++ b/python/minidaqapp/nanorc/fake_hsi_gen.py
@@ -117,7 +117,8 @@ def generate(
 
                 (f"ntoq_timesync_{idx}", ntoq.Conf(msg_type="dunedaq::dfmessages::TimeSync",
                                            msg_module_name="TimeSyncNQ",
-                                           receiver_config=nor.Conf(ipm_plugin_type="ZmqReceiver",
+                                           receiver_config=nor.Conf(ipm_plugin_type="ZmqSubscriber",
+								    subscriptions=["Timesync"],
                                                                     address=NETWORK_ENDPOINTS[inst])
                                            )
                 ) for idx, inst in enumerate(NETWORK_ENDPOINTS) if "timesync" in inst

--- a/python/minidaqapp/nanorc/mdapp_multiru_gen.py
+++ b/python/minidaqapp/nanorc/mdapp_multiru_gen.py
@@ -113,21 +113,21 @@ def cli(partition_name, number_of_data_producers, emulator_mode, data_rate_slowd
 
     if ers_impl == 'cern':
         use_kafka = True
-        ers_info = "erstrace,throttle(30,100),lstdout,erskafka(dqmbroadcast:9092)"
-        ers_warning = "erstrace,throttle(30,100),lstderr,erskafka(dqmbroadcast:9092)"
-        ers_error = "erstrace,throttle(30,100),lstderr,erskafka(dqmbroadcast:9092)"
+        ers_info = "erstrace,throttle,lstdout,erskafka(dqmbroadcast:9092)"
+        ers_warning = "erstrace,throttle,lstderr,erskafka(dqmbroadcast:9092)"
+        ers_error = "erstrace,throttle,lstderr,erskafka(dqmbroadcast:9092)"
         ers_fatal = "erstrace,lstderr,erskafka(dqmbroadcast:9092)"
     elif ers_impl == 'pocket':
         use_kafka = True
-        ers_info = "erstrace,throttle(30,100),lstdout,erskafka(" + pocket_url + ":9092)"
-        ers_warning = "erstrace,throttle(30,100),lstderr,erskafka(" + pocket_url + ":9092)"
-        ers_error = "erstrace,throttle(30,100),lstderr,erskafka(" + pocket_url + ":9092)"
-        ers_fatal = "erstrace,lstderr,erskafka(" + pocket_url + ":9092)"
+        ers_info = "erstrace,throttle,lstdout,erskafka(" + pocket_url + ":30092)"
+        ers_warning = "erstrace,throttle,lstderr,erskafka(" + pocket_url + ":30092)"
+        ers_error = "erstrace,throttle,lstderr,erskafka(" + pocket_url + ":30092)"
+        ers_fatal = "erstrace,lstderr,erskafka(" + pocket_url + ":30092)"
     else:
         use_kafka = False
-        ers_info = "erstrace,throttle(30,100),lstdout"
-        ers_warning = "erstrace,throttle(30,100),lstderr"
-        ers_error = "erstrace,throttle(30,100),lstderr"
+        ers_info = "erstrace,throttle,lstdout"
+        ers_warning = "erstrace,throttle,lstderr"
+        ers_error = "erstrace,throttle,lstderr"
         ers_fatal = "erstrace,lstderr"
 
     port = 12347

--- a/python/minidaqapp/nanorc/mdapp_multiru_gen.py
+++ b/python/minidaqapp/nanorc/mdapp_multiru_gen.py
@@ -49,11 +49,12 @@ import click
 @click.option('--enable-raw-recording', is_flag=True, help="Add queues and modules necessary for the record command")
 @click.option('--raw-recording-output-dir', type=click.Path(), default='.', help="Output directory where recorded data is written to. Data for each link is written to a separate file")
 @click.option('--frontend-type', type=click.Choice(['wib', 'wib2', 'pds_queue', 'pds_list']), default='wib', help="Frontend type (wib, wib2 or pds) and latency buffer implementation in case of pds (folly queue or skip list)")
+@click.option('--enable-dqm', is_flag=True, help="Enable Data Quality Monitoring")
 @click.argument('json_dir', type=click.Path())
 def cli(number_of_data_producers, emulator_mode, data_rate_slowdown_factor, run_number, trigger_rate_hz, trigger_window_before_ticks, trigger_window_after_ticks, token_count, data_file, output_path, enable_trace, use_felix, host_df, host_ru, host_trigger, host_hsi, 
         hsi_device_name, hsi_readout_period, use_hsi_hw, hsi_event_period, hsi_device_id, mean_hsi_signal_multiplicity, hsi_signal_emulation_mode, enabled_hsi_signals,
         ttcm_s1, ttcm_s2,
-        enable_raw_recording, raw_recording_output_dir, frontend_type, json_dir):
+        enable_raw_recording, raw_recording_output_dir, frontend_type, enable_dqm, json_dir):
     """
       JSON_DIR: Json file output folder
     """
@@ -180,7 +181,8 @@ def cli(number_of_data_producers, emulator_mode, data_rate_slowdown_factor, run_
             RAW_RECORDING_ENABLED = enable_raw_recording,
             RAW_RECORDING_OUTPUT_DIR = raw_recording_output_dir,
             FRONTEND_TYPE = frontend_type,
-            SYSTEM_TYPE = system_type
+            SYSTEM_TYPE = system_type,
+            DQM_ENABLED=enable_dqm
             ) for hostidx in range(len(host_ru))]
     console.log("readout cmd data:", cmd_data_readout)
 

--- a/python/minidaqapp/nanorc/readout_gen.py
+++ b/python/minidaqapp/nanorc/readout_gen.py
@@ -248,12 +248,13 @@ def generate(NETWORK_ENDPOINTS,
                         output_file = f"output_{idx + MIN_LINK}.out",
                         compression_algorithm = "None",
                         stream_buffer_size = 8388608)) for idx in range(NUMBER_OF_DATA_PRODUCERS)
+            ] + [
                 ("trb_dqm", trb.ConfParams(
                         general_queue_timeout=QUEUE_POP_WAIT_MS,
                         map=trb.mapgeoidqueue([
                                 trb.geoidinst(region=0, element=idx, system="TPC", queueinstance=f"data_requests_dqm_{idx}") for idx in range(NUMBER_OF_DATA_PRODUCERS)
                             ]),
-                        )),
+                        ))
             ] + [
                 ('dqmprocessor', dqmprocessor.Conf(
                         mode='debug' # normal or debug

--- a/python/minidaqapp/nanorc/readout_gen.py
+++ b/python/minidaqapp/nanorc/readout_gen.py
@@ -101,7 +101,7 @@ def generate(NETWORK_ENDPOINTS,
             app.QueueSpec(inst="trigger_decision_q_dqm", kind='FollySPSCQueue', capacity=20),
             app.QueueSpec(inst="trigger_record_q_dqm", kind='FollySPSCQueue', capacity=20),
         ] + [
-            app.QueueSpec(inst=f"data_requests_dqm_{idx}", kind='FollySPSCQueue', capacity=100)
+            app.QueueSpec(inst=f"data_requests_dqm_{idx+MIN_LINK}", kind='FollySPSCQueue', capacity=100)
                 for idx in range(NUMBER_OF_DATA_PRODUCERS)
         ]
 
@@ -134,7 +134,7 @@ def generate(NETWORK_ENDPOINTS,
 
         if DQM_ENABLED:
             ls.extend([
-            app.QueueInfo(name="data_requests_1", inst=f"data_requests_dqm_{idx}", dir="input"),
+            app.QueueInfo(name="data_requests_1", inst=f"data_requests_dqm_{idx+MIN_LINK}", dir="input"),
             app.QueueInfo(name="data_response_1", inst="data_fragments_q_dqm", dir="output")])
         mod_specs += [mspec(f"datahandler_{idx + MIN_LINK}", "DataLinkHandler", ls)]
 
@@ -155,7 +155,8 @@ def generate(NETWORK_ENDPOINTS,
                         app.QueueInfo(name="trigger_record_output_queue", inst="trigger_record_q_dqm", dir="output"),
                         app.QueueInfo(name="data_fragment_input_queue", inst="data_fragments_q_dqm", dir="input")
                     ] + [
-                        app.QueueInfo(name=f"data_request_{idx}_output_queue", inst=f"data_requests_dqm_{idx}", dir="output")
+                        app.QueueInfo(name=f"data_request_{idx}_output_queue", inst=f"data_requests_dqm_{idx+MIN_LINK}", dir="output")
+                            # for idx in range(NUMBER_OF_DATA_PRODUCERS)
                             for idx in range(NUMBER_OF_DATA_PRODUCERS)
                     ]),
         ]
@@ -252,7 +253,7 @@ def generate(NETWORK_ENDPOINTS,
                 ("trb_dqm", trb.ConfParams(
                         general_queue_timeout=QUEUE_POP_WAIT_MS,
                         map=trb.mapgeoidqueue([
-                                trb.geoidinst(region=0, element=idx, system="TPC", queueinstance=f"data_requests_dqm_{idx}") for idx in range(NUMBER_OF_DATA_PRODUCERS)
+                                trb.geoidinst(region=0, element=idx, system="TPC", queueinstance=f"data_requests_dqm_{idx+MIN_LINK}") for idx in range(NUMBER_OF_DATA_PRODUCERS)
                             ]),
                         ))
             ] + [

--- a/python/minidaqapp/nanorc/readout_gen.py
+++ b/python/minidaqapp/nanorc/readout_gen.py
@@ -257,7 +257,8 @@ def generate(NETWORK_ENDPOINTS,
                         ))
             ] + [
                 ('dqmprocessor', dqmprocessor.Conf(
-                        mode='debug' # normal or debug
+                        mode='debug', # normal or debug
+                        sdqm=[1, 1, 1],
                         ))
             ] + [
                 ("timesync_to_network", qton.Conf(msg_type="dunedaq::dfmessages::TimeSync",

--- a/python/minidaqapp/nanorc/readout_gen.py
+++ b/python/minidaqapp/nanorc/readout_gen.py
@@ -260,7 +260,7 @@ def generate(NETWORK_ENDPOINTS,
                         ))
             ] + [
                 ('dqmprocessor', dqmprocessor.Conf(
-                        mode='debug', # normal or debug
+                        mode='normal', # normal or debug
                         sdqm=[1, 1, 1],
                         kafka_address="dqmbroadcast:9092",
                         ))

--- a/python/minidaqapp/nanorc/readout_gen.py
+++ b/python/minidaqapp/nanorc/readout_gen.py
@@ -262,6 +262,7 @@ def generate(NETWORK_ENDPOINTS,
                 ('dqmprocessor', dqmprocessor.Conf(
                         mode='debug', # normal or debug
                         sdqm=[1, 1, 1],
+                        kafka_address="dqmbroadcast:9092",
                         ))
             ] + [
                 ("timesync_to_network", qton.Conf(msg_type="dunedaq::dfmessages::TimeSync",

--- a/python/minidaqapp/nanorc/readout_gen.py
+++ b/python/minidaqapp/nanorc/readout_gen.py
@@ -18,7 +18,7 @@ moo.otypes.load_types('flxlibs/felixcardreader.jsonnet')
 moo.otypes.load_types('readout/fakecardreader.jsonnet')
 moo.otypes.load_types('readout/datalinkhandler.jsonnet')
 moo.otypes.load_types('readout/datarecorder.jsonnet')
-
+moo.otypes.load_types('dqm/dqmprocessor.jsonnet')
 
 # Import new types
 import dunedaq.cmdlib.cmd as basecmd # AddressedCmd,
@@ -33,6 +33,8 @@ import dunedaq.readout.fakecardreader as fakecr
 import dunedaq.flxlibs.felixcardreader as flxcr
 import dunedaq.readout.datalinkhandler as dlh
 import dunedaq.readout.datarecorder as dr
+import dunedaq.dfmodules.triggerrecordbuilder as trb
+import dunedaq.dqm.dqmprocessor as dqmprocessor
 
 from appfwk.utils import acmd, mcmd, mrccmd, mspec
 
@@ -56,7 +58,8 @@ def generate(NETWORK_ENDPOINTS,
         RAW_RECORDING_ENABLED=False,
         RAW_RECORDING_OUTPUT_DIR=".",
         FRONTEND_TYPE='wib',
-        SYSTEM_TYPE='TPC'):
+        SYSTEM_TYPE='TPC',
+        DQM_ENABLED=False):
     """Generate the json configuration for the readout and DF process"""
 
     cmd_data = {}
@@ -90,42 +93,84 @@ def generate(NETWORK_ENDPOINTS,
             app.QueueSpec(inst=f"{FRONTEND_TYPE}_recording_link_{idx}", kind='FollySPSCQueue', capacity=100000)
             for idx in range(NUMBER_OF_DATA_PRODUCERS)
         ]
-    
+
+    if DQM_ENABLED:
+        queue_bare_specs += [
+            app.QueueSpec(inst=f"time_sync_dqm_q", kind='FollyMPMCQueue', capacity=1000),
+            app.QueueSpec(inst="data_fragments_q_dqm", kind='FollyMPMCQueue', capacity=1000),
+            app.QueueSpec(inst="trigger_decision_q_dqm", kind='FollySPSCQueue', capacity=20),
+            app.QueueSpec(inst="trigger_record_q_dqm", kind='FollySPSCQueue', capacity=20),
+        ] + [
+            app.QueueSpec(inst=f"data_requests_dqm_{idx}", kind='FollySPSCQueue', capacity=100)
+                for idx in range(MIN_LINK,MAX_LINK)
+        ]
 
     # Only needed to reproduce the same order as when using jsonnet
     queue_specs = app.QueueSpecs(sorted(queue_bare_specs, key=lambda x: x.inst))
 
     mod_specs = [
-        mspec("qton_timesync", "QueueToNetwork", [app.QueueInfo(name="input", inst="time_sync_q", dir="input")]),
+        # mspec("qton_timesync", "QueueToNetwork", [app.QueueInfo(name="input", inst="time_sync_q", dir="input")]),
         mspec("qton_fragments", "QueueToNetwork", [app.QueueInfo(name="input", inst="data_fragments_q", dir="input")]),
     ] + [
         mspec(f"ntoq_datareq_{idx}", "NetworkToQueue", [app.QueueInfo(name="output", inst=f"data_requests_{idx}", dir="output")]) for idx in range(MIN_LINK,MAX_LINK)
     ]
 
-    if RAW_RECORDING_ENABLED:
-        mod_specs = mod_specs + [
-            mspec(f"datahandler_{idx + MIN_LINK}", "DataLinkHandler", [
+
+    # There are two flags to be checked so a for loop is a compromise between
+    # so it's hard to make it in a single block without it being very ugly
+
+    for idx in range(NUMBER_OF_DATA_PRODUCERS):
+        ls = [
                 app.QueueInfo(name="raw_input", inst=f"{FRONTEND_TYPE}_link_{idx}", dir="input"),
                 app.QueueInfo(name="timesync", inst="time_sync_q", dir="output"),
-                app.QueueInfo(name="requests", inst=f"data_requests_{idx + MIN_LINK}", dir="input"),
-                app.QueueInfo(name="fragments", inst="data_fragments_q", dir="output"),
-                app.QueueInfo(name="raw_recording", inst=f"{FRONTEND_TYPE}_recording_link_{idx}", dir="output")
-            ]) for idx in range(NUMBER_OF_DATA_PRODUCERS)
-        ] + [
+                app.QueueInfo(name="data_requests_0", inst=f"data_requests_{idx + MIN_LINK}", dir="input"),
+                app.QueueInfo(name="data_response_0", inst="data_fragments_q", dir="output"),
+            ]
+
+        if RAW_RECORDING_ENABLED:
+            ls.append(app.QueueInfo(name="raw_recording", inst=f"{FRONTEND_TYPE}_recording_link_{idx}", dir="output"))
+        else: # This else can be removed once readout doesn't always check for the raw_recording queue
+            ls.append(app.QueueInfo(name="raw_recording", inst=f"{FRONTEND_TYPE}_recording_link_{idx}", dir="output"))
+
+        if DQM_ENABLED:
+            ls.extend([
+            app.QueueInfo(name="data_requests_1", inst=f"data_requests_dqm_{idx + MIN_LINK}", dir="input"),
+            app.QueueInfo(name="data_response_1", inst="data_fragments_q_dqm", dir="output")])
+        mod_specs += [mspec(f"datahandler_{idx + MIN_LINK}", "DataLinkHandler", ls)]
+
+    if RAW_RECORDING_ENABLED:
+        mod_specs += [
             mspec(f"data_recorder_{idx}", "DataRecorder", [
                 app.QueueInfo(name="raw_recording", inst=f"{FRONTEND_TYPE}_recording_link_{idx}", dir="input")
             ]) for idx in range(NUMBER_OF_DATA_PRODUCERS)
         ]
-    else:
-        mod_specs = mod_specs + [
-            mspec(f"datahandler_{idx + MIN_LINK}", "DataLinkHandler", [
-                app.QueueInfo(name="raw_input", inst=f"{FRONTEND_TYPE}_link_{idx}", dir="input"),
-                app.QueueInfo(name="timesync", inst="time_sync_q", dir="output"),
-                app.QueueInfo(name="requests", inst=f"data_requests_{idx + MIN_LINK}", dir="input"),
-                app.QueueInfo(name="fragments", inst="data_fragments_q", dir="output")
-            ]) for idx in range(NUMBER_OF_DATA_PRODUCERS)
+
+    mod_specs += [mspec("timesync_to_network", "QueueToNetwork",
+              [app.QueueInfo(name="input", inst="time_sync_q", dir="input")]
+              )]
+
+    if DQM_ENABLED:
+        mod_specs += [mspec("trb_dqm", "TriggerRecordBuilder", [
+                        app.QueueInfo(name="trigger_decision_input_queue", inst="trigger_decision_q_dqm", dir="input"),
+                        app.QueueInfo(name="trigger_record_output_queue", inst="trigger_record_q_dqm", dir="output"),
+                        app.QueueInfo(name="data_fragment_input_queue", inst="data_fragments_q_dqm", dir="input")
+                    ] + [
+                        app.QueueInfo(name=f"data_request_{idx}_output_queue", inst=f"data_requests_dqm_{idx}", dir="output")
+                            for idx in range(NUMBER_OF_DATA_PRODUCERS)
+                    ]),
+        ]
+        mod_specs += [mspec("dqmprocessor", "DQMProcessor", [
+                        app.QueueInfo(name="trigger_record_dqm_processor", inst="trigger_record_q_dqm", dir="input"),
+                        app.QueueInfo(name="trigger_decision_dqm_processor", inst="trigger_decision_q_dqm", dir="output"),
+                        # app.QueueInfo(name="timesync_dqm_processor", inst="time_sync_q", dir="input"),
+                        app.QueueInfo(name="timesync_dqm_processor", inst="time_sync_dqm_q", dir="input"),
+                    ]),
+
         ]
 
+        mod_specs += [mspec("dqm_subscriber", "NetworkToQueue",
+                [app.QueueInfo(name="output", inst="time_sync_dqm_q", dir="output")]
+                )]
     if FLX_INPUT:
         mod_specs.append(mspec("flxcard_0", "FelixCardReader", [
                         app.QueueInfo(name=f"output_{idx}", inst=f"{FRONTEND_TYPE}_link_{idx}", dir="output")
@@ -203,6 +248,36 @@ def generate(NETWORK_ENDPOINTS,
                         output_file = f"output_{idx + MIN_LINK}.out",
                         compression_algorithm = "None",
                         stream_buffer_size = 8388608)) for idx in range(NUMBER_OF_DATA_PRODUCERS)
+                ("trb_dqm", trb.ConfParams(
+                        general_queue_timeout=QUEUE_POP_WAIT_MS,
+                        map=trb.mapgeoidqueue([
+                                trb.geoidinst(region=0, element=idx, system="TPC", queueinstance=f"data_requests_dqm_{idx}") for idx in range(NUMBER_OF_DATA_PRODUCERS)
+                            ]),
+                        )),
+            ] + [
+                ('dqmprocessor', dqmprocessor.Conf(
+                        mode='debug' # normal or debug
+                        ))
+            ] + [
+                ("timesync_to_network", qton.Conf(msg_type="dunedaq::dfmessages::TimeSync",
+                                msg_module_name="TimeSyncNQ",
+                                sender_config=nos.Conf(ipm_plugin_type="ZmqPublisher",
+                                                        address=NETWORK_ENDPOINTS[f"timesync_{HOSTIDX}"],
+                                                        topic="Timesync",
+                                                        stype="msgpack")
+                                )
+                )
+            ] + [
+                ("dqm_subscriber", ntoq.Conf(msg_type="dunedaq::dfmessages::TimeSync",
+                                msg_module_name="TimeSyncNQ",
+                                receiver_config=nor.Conf(ipm_plugin_type="ZmqSubscriber",
+                                                        address=NETWORK_ENDPOINTS[f"timesync_{HOSTIDX}"],
+                                                        subscriptions=["Timesync"],
+                                                        # stype="msgpack")
+                                                         )
+                                )
+                )
+
     ])
 
 
@@ -214,7 +289,9 @@ def generate(NETWORK_ENDPOINTS,
             ("fake_source", startpars),
             ("flxcard.*", startpars),
             ("ntoq_datareq_.*", startpars),
-            ("ntoq_trigdec", startpars),])
+            ("ntoq_trigdec", startpars),
+            ("trb_dqm", startpars),
+            ("dqmprocessor", startpars),])
 
     cmd_data['stop'] = acmd([("ntoq_trigdec", None),
             ("ntoq_datareq_.*", None),
@@ -223,7 +300,9 @@ def generate(NETWORK_ENDPOINTS,
             ("datahandler_.*", None),
             ("data_recorder_.*", None),
             ("qton_timesync", None),
-            ("qton_fragments", None),])
+            ("qton_fragments", None),
+            ("trb_dqm", None),
+            ("dqmprocessor", None),])
 
     cmd_data['pause'] = acmd([("", None)])
 

--- a/python/minidaqapp/nanorc/readout_gen.py
+++ b/python/minidaqapp/nanorc/readout_gen.py
@@ -102,7 +102,7 @@ def generate(NETWORK_ENDPOINTS,
             app.QueueSpec(inst="trigger_record_q_dqm", kind='FollySPSCQueue', capacity=20),
         ] + [
             app.QueueSpec(inst=f"data_requests_dqm_{idx}", kind='FollySPSCQueue', capacity=100)
-                for idx in range(MIN_LINK,MAX_LINK)
+                for idx in range(NUMBER_OF_DATA_PRODUCERS)
         ]
 
     # Only needed to reproduce the same order as when using jsonnet
@@ -134,7 +134,7 @@ def generate(NETWORK_ENDPOINTS,
 
         if DQM_ENABLED:
             ls.extend([
-            app.QueueInfo(name="data_requests_1", inst=f"data_requests_dqm_{idx + MIN_LINK}", dir="input"),
+            app.QueueInfo(name="data_requests_1", inst=f"data_requests_dqm_{idx}", dir="input"),
             app.QueueInfo(name="data_response_1", inst="data_fragments_q_dqm", dir="output")])
         mod_specs += [mspec(f"datahandler_{idx + MIN_LINK}", "DataLinkHandler", ls)]
 

--- a/python/minidaqapp/nanorc/readout_gen.py
+++ b/python/minidaqapp/nanorc/readout_gen.py
@@ -116,8 +116,8 @@ def generate(NETWORK_ENDPOINTS,
     ]
 
 
-    # There are two flags to be checked so a for loop is a compromise between
-    # so it's hard to make it in a single block without it being very ugly
+    # There are two flags to be checked so I think a for loop
+    # is the closest way to the blocks that are being used here
 
     for idx in range(NUMBER_OF_DATA_PRODUCERS):
         ls = [
@@ -129,7 +129,9 @@ def generate(NETWORK_ENDPOINTS,
 
         if RAW_RECORDING_ENABLED:
             ls.append(app.QueueInfo(name="raw_recording", inst=f"{FRONTEND_TYPE}_recording_link_{idx}", dir="output"))
-        else: # This else can be removed once readout doesn't always check for the raw_recording queue
+        else:
+            # This else can be removed once readout doesn't always check for the raw_recording queue
+            # At the moment it is needed or it won't find the queue and crash
             ls.append(app.QueueInfo(name="raw_recording", inst=f"{FRONTEND_TYPE}_recording_link_{idx}", dir="output"))
 
         if DQM_ENABLED:


### PR DESCRIPTION
There are two major changes:

- DQM is included in the readout configuration for now
- Changes in the readout configuration using the publish-subscribe model. It goes together with some changes in readout that have been merged today

There is a new flag, `--enable-dqm` to enable DQM (by default disabled). The tests I have done with and without DQM with one or two readout apps have worked fine