### PR TITLE
Add software TP generation and TP->TA->TC chain in trigger

### DIFF
--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -47,7 +47,7 @@ jobs:
     - name: setup dev area
       run: |
           source $GITHUB_WORKSPACE/daq-buildtools/env.sh
-          dbt-create.sh -r /releases dunedaq-develop dev
+          dbt-create.sh -n last_successful dev
           
     - name: checkout package for CI
       uses: actions/checkout@v2

--- a/python/minidaqapp/nanorc/mdapp_multiru_gen.py
+++ b/python/minidaqapp/nanorc/mdapp_multiru_gen.py
@@ -191,8 +191,8 @@ def cli(partition_name, number_of_data_producers, emulator_mode, data_rate_slowd
     console.log("hsi cmd data:", cmd_data_hsi)
 
     cmd_data_trigger = trigger_gen.generate(network_endpoints,
-        TOTAL_NUMBER_OF_DATA_PRODUCERS = total_number_of_data_producers,
-        SUBSCRIBE_TO_TPSETS = enable_software_tpg,
+        NUMBER_OF_RAWDATA_PRODUCERS = total_number_of_data_producers,
+        NUMBER_OF_TPSET_PRODUCERS = total_number_of_data_producers if enable_software_tpg else 0,
         ACTIVITY_PLUGIN = trigger_activity_plugin,
         ACTIVITY_CONFIG = eval(trigger_activity_config),
         CANDIDATE_PLUGIN = trigger_candidate_plugin,
@@ -202,8 +202,8 @@ def cli(partition_name, number_of_data_producers, emulator_mode, data_rate_slowd
         TTCM_S1=ttcm_s1,
         TTCM_S2=ttcm_s2,
         TRIGGER_WINDOW_BEFORE_TICKS = trigger_window_before_ticks,
-        TRIGGER_WINDOW_AFTER_TICKS = trigger_window_after_ticks,
-        SOFTWARE_TPG_ENABLED = enable_software_tpg)
+        TRIGGER_WINDOW_AFTER_TICKS = trigger_window_after_ticks)
+
 
     console.log("trigger cmd data:", cmd_data_trigger)
 

--- a/python/minidaqapp/nanorc/mdapp_multiru_gen.py
+++ b/python/minidaqapp/nanorc/mdapp_multiru_gen.py
@@ -17,7 +17,7 @@ console = Console()
 import click
 
 @click.command(context_settings=CONTEXT_SETTINGS)
-@click.option('-n', '--number-of-data-producers', default=2, help="Number of links to use, either per ru (<10) or total. If total is given, will be adjusted to the closest multiple of the number of rus")
+@click.option('-n', '--number-of-data-producers', default=2, help="Number of links to use, either per ru (<=10) or total. If total is given, will be adjusted to the closest multiple of the number of rus")
 @click.option('-e', '--emulator-mode', is_flag=True, help="If active, timestamps of data frames are overwritten when processed by the readout. This is necessary if the felix card does not set correct timestamps.")
 @click.option('-s', '--data-rate-slowdown-factor', default=1)
 @click.option('-r', '--run-number', default=333)

--- a/python/minidaqapp/nanorc/mdapp_multiru_gen.py
+++ b/python/minidaqapp/nanorc/mdapp_multiru_gen.py
@@ -261,7 +261,7 @@ def cli(partition_name, number_of_data_producers, emulator_mode, data_rate_slowd
 
 
     console.log(f"Generating top-level command json files")
-    start_order = [app_df] + app_ru + [app_trigger] + [app_hsi]
+    start_order = [app_df] + [app_trigger] + app_ru + [app_hsi]
     for c in cmd_set:
         with open(join(json_dir,f'{c}.json'), 'w') as f:
             cfg = {

--- a/python/minidaqapp/nanorc/mdapp_multiru_gen.py
+++ b/python/minidaqapp/nanorc/mdapp_multiru_gen.py
@@ -46,6 +46,10 @@ import click
 # trigger options
 @click.option('--ttcm-s1', default=1, help="Timing trigger candidate maker accepted HSI signal ID 1")
 @click.option('--ttcm-s2', default=2, help="Timing trigger candidate maker accepted HSI signal ID 2")
+@click.option('--trigger-activity-plugin', default='TriggerActivityMakerPrescalePlugin', help="Trigger activity algorithm plugin")
+@click.option('--trigger-activity-config', default='dict(prescale=100)', help="Trigger activity algorithm config (string containing python dictionary)")
+@click.option('--trigger-candidate-plugin', default='TriggerCandidateMakerPrescalePlugin', help="Trigger candidate algorithm plugin")
+@click.option('--trigger-candidate-config', default='dict(prescale=100)', help="Trigger candidate algorithm config (string containing python dictionary)")
 
 @click.option('--enable-raw-recording', is_flag=True, help="Add queues and modules necessary for the record command")
 @click.option('--raw-recording-output-dir', type=click.Path(), default='.', help="Output directory where recorded data is written to. Data for each link is written to a separate file")
@@ -60,7 +64,7 @@ import click
 def cli(partition_name, number_of_data_producers, emulator_mode, data_rate_slowdown_factor, run_number, trigger_rate_hz, trigger_window_before_ticks, trigger_window_after_ticks,
         token_count, data_file, output_path, disable_trace, use_felix, host_df, host_ru, host_trigger, host_hsi, 
         hsi_device_name, hsi_readout_period, use_hsi_hw, hsi_device_id, mean_hsi_signal_multiplicity, hsi_signal_emulation_mode, enabled_hsi_signals,
-        ttcm_s1, ttcm_s2,
+        ttcm_s1, ttcm_s2, trigger_activity_plugin, trigger_activity_config, trigger_candidate_plugin, trigger_candidate_config,
         enable_raw_recording, raw_recording_output_dir, frontend_type, opmon_impl, enable_dqm, ers_impl, pocket_url, enable_software_tpg, json_dir):
     """
       JSON_DIR: Json file output folder
@@ -187,7 +191,12 @@ def cli(partition_name, number_of_data_producers, emulator_mode, data_rate_slowd
     console.log("hsi cmd data:", cmd_data_hsi)
 
     cmd_data_trigger = trigger_gen.generate(network_endpoints,
-        NUMBER_OF_DATA_PRODUCERS = total_number_of_data_producers,
+        TOTAL_NUMBER_OF_DATA_PRODUCERS = total_number_of_data_producers,
+        SUBSCRIBE_TO_TPSETS = enable_software_tpg,
+        ACTIVITY_PLUGIN = trigger_activity_plugin,
+        ACTIVITY_CONFIG = eval(trigger_activity_config),
+        CANDIDATE_PLUGIN = trigger_candidate_plugin,
+        CANDIDATE_CONFIG = eval(trigger_candidate_config),
         TOKEN_COUNT = trigemu_token_count,
         SYSTEM_TYPE = system_type,
         TTCM_S1=ttcm_s1,

--- a/python/minidaqapp/nanorc/mdapp_multiru_gen.py
+++ b/python/minidaqapp/nanorc/mdapp_multiru_gen.py
@@ -325,7 +325,8 @@ def cli(partition_name, number_of_data_producers, emulator_mode, data_rate_slowd
                 "DUNEDAQ_ERS_INFO": ers_info,
                 "DUNEDAQ_ERS_WARNING": ers_warning,
                 "DUNEDAQ_ERS_ERROR": ers_error,
-                "DUNEDAQ_ERS_FATAL": ers_fatal
+                "DUNEDAQ_ERS_FATAL": ers_fatal,
+                "DUNEDAQ_ERS_DEBUG_LEVEL": "getenv:-1",
             },
             "hosts": {
                 "host_df": host_df,

--- a/python/minidaqapp/nanorc/trigger_gen.py
+++ b/python/minidaqapp/nanorc/trigger_gen.py
@@ -9,6 +9,9 @@ moo.otypes.load_types('rcif/cmd.jsonnet')
 moo.otypes.load_types('appfwk/cmd.jsonnet')
 moo.otypes.load_types('appfwk/app.jsonnet')
 
+moo.otypes.load_types('trigger/triggeractivitymaker.jsonnet')
+moo.otypes.load_types('trigger/triggercandidatemaker.jsonnet')
+moo.otypes.load_types('trigger/triggerzipper.jsonnet')
 moo.otypes.load_types('trigger/intervaltccreator.jsonnet')
 moo.otypes.load_types('trigger/moduleleveltrigger.jsonnet')
 moo.otypes.load_types('trigger/fakedataflow.jsonnet')
@@ -25,6 +28,9 @@ import dunedaq.rcif.cmd as rccmd # AddressedCmd,
 import dunedaq.appfwk.cmd as cmd # AddressedCmd, 
 import dunedaq.appfwk.app as app # AddressedCmd,
 import dunedaq.trigger.intervaltccreator as itcc
+import dunedaq.trigger.triggeractivitymaker as tam
+import dunedaq.trigger.triggercandidatemaker as tcm
+import dunedaq.trigger.triggerzipper as tzip
 import dunedaq.trigger.moduleleveltrigger as mlt
 import dunedaq.trigger.fakedataflow as fdf
 import dunedaq.trigger.timingtriggercandidatemaker as ttcm
@@ -41,10 +47,36 @@ import math
 from pprint import pprint
 
 
+#FIXME maybe one day, triggeralgs will define schemas... for now allow a dictionary of 4byte int, 4byte floats, and strings
+moo.otypes.make_type(schema='number', dtype='i4', name='temp_integer', path='temptypes')
+moo.otypes.make_type(schema='number', dtype='f4', name='temp_float', path='temptypes')
+moo.otypes.make_type(schema='string', name='temp_string', path='temptypes')
+def make_moo_record(conf_dict,name,path='temptypes'):
+    fields = []
+    for pname,pvalue in conf_dict.items():
+        typename = None
+        if type(pvalue) == int:
+            typename = 'temptypes.temp_integer'
+        elif type(pvalue) == float:
+            typename = 'temptypes.temp_float'
+        elif type(pvalue) == str:
+            typename = 'temptypes.temp_string'
+        else:
+            raise Exception(f'Invalid config argument type: {type(value)}')
+        fields.append(dict(name=pname,item=typename))
+    moo.otypes.make_type(schema='record', fields=fields, name=name, path=path)
+    
 #===============================================================================
 def generate(
         NETWORK_ENDPOINTS: list,
         NUMBER_OF_DATA_PRODUCERS: int = 2,
+        
+        ACTIVITY_PLUGIN: str = 'TriggerActivityMakerPrescalePlugin',
+        ACTIVITY_CONFIG: dict = dict(prescale=1000),
+        
+        CANDIDATE_PLUGIN: str = 'TriggerCandidateMakerPrescalePlugin',
+        CANDIDATE_CONFIG: int = dict(prescale=1000),
+        
         TOKEN_COUNT: int = 10,
         SYSTEM_TYPE = 'wib',
         TTCM_S1: int = 1,
@@ -62,83 +94,167 @@ def generate(
 
     # Define modules and queues
     queue_bare_specs = [
+        app.QueueSpec(inst="tpsets_from_netq", kind='FollyMPMCQueue', capacity=1000),
+        app.QueueSpec(inst='zipped_tpset_q', kind='FollySPSCQueue', capacity=1000),
+        app.QueueSpec(inst='taset_q', kind='FollySPSCQueue', capacity=1000),
+        app.QueueSpec(inst='trigger_candidate_q', kind='FollyMPMCQueue', capacity=1000),
         app.QueueSpec(inst="hsievent_from_netq", kind='FollyMPMCQueue', capacity=1000),
-        app.QueueSpec(inst="token_from_netq", kind='FollySPSCQueue', capacity=2000),        
-        app.QueueSpec(inst="trigger_decision_to_netq", kind='FollySPSCQueue', capacity=2000),
-        app.QueueSpec(inst="trigger_candidate_q", kind='FollySPSCQueue', capacity=2000),
+        app.QueueSpec(inst="token_from_netq", kind='FollySPSCQueue', capacity=1000),        
+        app.QueueSpec(inst="trigger_decision_to_netq", kind='FollySPSCQueue', capacity=1000),
     ]
 
     # Only needed to reproduce the same order as when using jsonnet
     queue_specs = app.QueueSpecs(sorted(queue_bare_specs, key=lambda x: x.inst))
 
     mod_specs = [
-
+        
+        ### TPSet input
+        
+        ] + [
+            mspec(f"tpset_subscriber_{idx}", "NetworkToQueue", [ 
+                app.QueueInfo(name="output", inst=f"tpsets_from_netq", dir="output")
+            ]) for idx in range(NUMBER_OF_DATA_PRODUCERS)
+        ] + [
+        
+        mspec("zip", "TPZipper", [
+            app.QueueInfo(name="input", inst="tpsets_from_netq", dir="input"),
+            app.QueueInfo(name="output", inst="zipped_tpset_q", dir="output"), #FIXME need to fanout this zipped_tpset_q if using multiple algorithms
+        ]),
+        
+        ### Algorithms
+        
+        mspec('tam', 'TriggerActivityMaker', [ # TPSet -> TASet
+            app.QueueInfo(name='input', inst='zipped_tpset_q', dir='input'),
+            app.QueueInfo(name='output', inst='taset_q', dir='output'),
+        ]),
+        
+        mspec('tcm', 'TriggerCandidateMaker', [ # TASet -> TC
+            app.QueueInfo(name='input', inst='taset_q', dir='input'),
+            app.QueueInfo(name='output', inst='trigger_candidate_q', dir='output'),
+        ]),
+        
+        ### Timing TCs
+        
         mspec("ntoq_hsievent", "NetworkToQueue", [
-                        app.QueueInfo(name="output", inst="hsievent_from_netq", dir="output")
-                    ]),
-
-        mspec("ntoq_token", "NetworkToQueue", [
-                        app.QueueInfo(name="output", inst="token_from_netq", dir="output")
-                    ]),
-
-        mspec("qton_trigdec", "QueueToNetwork", [
-                        app.QueueInfo(name="input", inst="trigger_decision_to_netq", dir="input")
-                    ]),
-
-        mspec("mlt", "ModuleLevelTrigger", [
-            app.QueueInfo(name="token_source", inst="token_from_netq", dir="input"),
-            app.QueueInfo(name="trigger_decision_sink", inst="trigger_decision_to_netq", dir="output"),
-            app.QueueInfo(name="trigger_candidate_source", inst="trigger_candidate_q", dir="output"),
+            app.QueueInfo(name="output", inst="hsievent_from_netq", dir="output")
         ]),
 
         mspec("ttcm", "TimingTriggerCandidateMaker", [
             app.QueueInfo(name="input", inst="hsievent_from_netq", dir="input"),
             app.QueueInfo(name="output", inst="trigger_candidate_q", dir="output"),
         ]),
+        
+        ### Module level trigger
+
+        mspec("ntoq_token", "NetworkToQueue", [
+            app.QueueInfo(name="output", inst="token_from_netq", dir="output")
+        ]),
+
+        mspec("qton_trigdec", "QueueToNetwork", [
+            app.QueueInfo(name="input", inst="trigger_decision_to_netq", dir="input")
+        ]),
+
+        mspec("mlt", "ModuleLevelTrigger", [
+            app.QueueInfo(name="token_source", inst="token_from_netq", dir="input"),
+            app.QueueInfo(name="trigger_decision_sink", inst="trigger_decision_to_netq", dir="output"),
+            app.QueueInfo(name="trigger_candidate_source", inst="trigger_candidate_q", dir="input"),
+        ]),
 
 
     ]
 
     cmd_data['init'] = app.Init(queues=queue_specs, modules=mod_specs)
-
+    
+    # Generate schema for the maker plugins on the fly in the temptypes module
+    make_moo_record(ACTIVITY_CONFIG,'ActivityConf','temptypes')
+    make_moo_record(CANDIDATE_CONFIG,'CandidateConf','temptypes')
+    import temptypes
+    
     cmd_data['conf'] = acmd([
+        
+        ### TPSet input
+        ] + [
+            (f"tpset_subscriber_{idx}", ntoq.Conf(
+                msg_type="dunedaq::trigger::TPSet",
+                msg_module_name="TPSetNQ",
+                #FIXME this info needs to come from readout / NETWORK_ENDPOINTS
+                receiver_config=nor.Conf(ipm_plugin_type="ZmqSubscriber",
+                                         address=f'tcp://127.0.0.1:{5000+idx}',
+                                         subscriptions=["foo"])
+            ))
+            for idx in range(NUMBER_OF_DATA_PRODUCERS)
+        ] + [
+        
+        ("zip", tzip.ConfParams(
+             cardinality=NUMBER_OF_DATA_PRODUCERS,
+             max_latency_ms=1000,
+             region_id=0, # Fake placeholder
+             element_id=0 # Fake placeholder
+        )),
+        
+        ### Algorithms
+        
+        ('tam', tam.Conf(
+            activity_maker=ACTIVITY_PLUGIN,
+            geoid_region=0, # Fake placeholder
+            geoid_element=0, # Fake placeholder
+            window_time=10000, # should match whatever makes TPSets, in principle
+            buffer_time=625000, # 10ms in 62.5 MHz ticks
+            activity_maker_config=temptypes.ActivityConf(**ACTIVITY_CONFIG)
+        )),
+        
+        ('tcm', tcm.Conf(
+            candidate_maker=CANDIDATE_PLUGIN,
+            candidate_maker_config=temptypes.CandidateConf(**CANDIDATE_CONFIG)
+        )),
+        
+        ### Timing TCs
+        
+        ("ntoq_hsievent", ntoq.Conf(
+            msg_type="dunedaq::dfmessages::HSIEvent",
+            msg_module_name="HSIEventNQ",
+            receiver_config=nor.Conf(ipm_plugin_type="ZmqReceiver",
+                                     address=NETWORK_ENDPOINTS["hsievent"])
+        )),
+                
+        ("ttcm", ttcm.Conf(
+            s1=ttcm.map_t(signal_type=TTCM_S1,
+                          time_before=TRIGGER_WINDOW_BEFORE_TICKS,
+                          time_after=TRIGGER_WINDOW_AFTER_TICKS),
+            s2=ttcm.map_t(signal_type=TTCM_S2,
+                          time_before=TRIGGER_WINDOW_BEFORE_TICKS,
+                          time_after=TRIGGER_WINDOW_AFTER_TICKS)
+            )
+        ),
+
+        # Module level trigger
+        
+        ("ntoq_token", ntoq.Conf(
+            msg_type="dunedaq::dfmessages::TriggerDecisionToken",
+            msg_module_name="TriggerDecisionTokenNQ",
+            receiver_config=nor.Conf(ipm_plugin_type="ZmqReceiver",
+                                     address=NETWORK_ENDPOINTS["triginh"])
+        )),
+        
+        ("qton_trigdec", qton.Conf(
+            msg_type="dunedaq::dfmessages::TriggerDecision",
+            msg_module_name="TriggerDecisionNQ",
+            sender_config=nos.Conf(ipm_plugin_type="ZmqSender",
+                                   address=NETWORK_ENDPOINTS["trigdec"])
+        )),
+        
         ("mlt", mlt.ConfParams(
             links=[mlt.GeoID(system=SYSTEM_TYPE, region=0, element=idx) for idx in range(NUMBER_OF_DATA_PRODUCERS)],
             initial_token_count=TOKEN_COUNT                    
         )),
-        
-        ("ttcm", ttcm.Conf(
-                        s1=ttcm.map_t(signal_type=TTCM_S1,
-                                      time_before=TRIGGER_WINDOW_BEFORE_TICKS,
-                                      time_after=TRIGGER_WINDOW_AFTER_TICKS),
-                        s2=ttcm.map_t(signal_type=TTCM_S2,
-                                      time_before=TRIGGER_WINDOW_BEFORE_TICKS,
-                                      time_after=TRIGGER_WINDOW_AFTER_TICKS)
-                        )
-        ),
-
-        ("ntoq_hsievent", ntoq.Conf(msg_type="dunedaq::dfmessages::HSIEvent",
-                                           msg_module_name="HSIEventNQ",
-                                           receiver_config=nor.Conf(ipm_plugin_type="ZmqReceiver",
-                                                                    address=NETWORK_ENDPOINTS["hsievent"])
-                                           )
-                ),
-        ("ntoq_token", ntoq.Conf(msg_type="dunedaq::dfmessages::TriggerDecisionToken",
-                                           msg_module_name="TriggerDecisionTokenNQ",
-                                           receiver_config=nor.Conf(ipm_plugin_type="ZmqReceiver",
-                                                                    address=NETWORK_ENDPOINTS["triginh"])
-                                           )
-                ),
-        ("qton_trigdec", qton.Conf(msg_type="dunedaq::dfmessages::TriggerDecision",
-                                           msg_module_name="TriggerDecisionNQ",
-                                           sender_config=nos.Conf(ipm_plugin_type="ZmqSender",
-                                                                    address=NETWORK_ENDPOINTS["trigdec"])
-                                           )
-                ),
     ])
 
     startpars = rccmd.StartParams(run=1)
     cmd_data['start'] = acmd([
+        ("tpset_subscriber", startpars),
+        ("zip", startpars),
+        ("tam", startpars),
+        ("tcm", startpars),
         ("mlt", startpars),
         ("ttcm", startpars),
         ("ntoq_hsievent", startpars),
@@ -147,11 +263,15 @@ def generate(
     ])
 
     cmd_data['stop'] = acmd([
+        ("tpset_subscriber", None),
+        ("zip", None),
+        ("tam", None),
+        ("tcm", None),
         ("mlt", None),
         ("ttcm", None),
         ("ntoq_hsievent", None),
-        ("ntoq_token", startpars),
-        ("qton_trigdec", startpars),
+        ("ntoq_token", None),
+        ("qton_trigdec", None),
     ])
 
     cmd_data['pause'] = acmd([


### PR DESCRIPTION
This PR adds software TP generation to the readout app, and reception of those TPs in the trigger app. The trigger app sends the TPs through a TP -> TA -> TC chain which is fed into the MLT.

The PR includes buffering and data requests for the "raw" TPs from the readout app, but no buffering of TPs in the trigger app.

The default `frames.bin` file won't give enough TPs for any useful tests. Better results will be obtained with the larger file mentioned here:

https://github.com/DUNE-DAQ/readout/#enabling-the-software-tpg

For my tests I used:

```
python -m minidaqapp.nanorc.mdapp_multiru_gen -n 2 -s 10 -t 1 --host-ru localhost --data-file felix-2020-06-02-093338.0.0.0.bin --enable-software-tpg json
```

The number of triggers reported in the trigger app log is sensible, and matches the number of TRs I see in the output file. Each TR has four fragments - two from the 2 raw data outputs (which have the same size across TRs) and two from the TPs (different sizes across TRs).