### PR TITLE
Option to use fake data producers

### DIFF
--- a/python/minidaqapp/nanorc/readout_gen.py
+++ b/python/minidaqapp/nanorc/readout_gen.py
@@ -382,7 +382,7 @@ def generate(NETWORK_ENDPOINTS,
                         ])
 
     if USE_FAKE_DATA_PRODUCERS:
-        conf_list.extend(+ [
+        conf_list.extend([
             (f"fakedataprod_{idx}", fdp.Conf(
                 system_type = SYSTEM_TYPE,
                 apa_number = 0,
@@ -390,7 +390,7 @@ def generate(NETWORK_ENDPOINTS,
                 time_tick_diff = 25,
                 frame_size = 464,
                 response_delay = 0,
-                fragment_type = "kTPCData")) for idx in range(MIN_LINK,MAX_LINK)
+                fragment_type = "FakeData")) for idx in range(MIN_LINK,MAX_LINK)
         ])
 
     cmd_data['conf'] = acmd(conf_list)


### PR DESCRIPTION
This adds an option to use fake data producers that always answer with empty fragments upon request. One fake data producer replaces the (fake) card reader and DLH combination. The fake data producer module can not be used with software tpg or the DQM in its current state. The latter is because it would require adding more queues to it. 