### PR TITLE
Added TPSet writing from the DF App in the mdapp_multiru confgen

### DIFF
--- a/python/minidaqapp/nanorc/dataflow_gen.py
+++ b/python/minidaqapp/nanorc/dataflow_gen.py
@@ -10,11 +10,10 @@ moo.otypes.load_types('rcif/cmd.jsonnet')
 moo.otypes.load_types('appfwk/cmd.jsonnet')
 moo.otypes.load_types('appfwk/app.jsonnet')
 
-#moo.otypes.load_types('trigemu/faketimesyncsource.jsonnet')
 moo.otypes.load_types('dfmodules/triggerrecordbuilder.jsonnet')
 moo.otypes.load_types('dfmodules/datawriter.jsonnet')
 moo.otypes.load_types('dfmodules/hdf5datastore.jsonnet')
-#moo.otypes.load_types('dfmodules/fakedataprod.jsonnet')
+moo.otypes.load_types('dfmodules/tpsetwriter.jsonnet')
 moo.otypes.load_types('nwqueueadapters/queuetonetwork.jsonnet')
 moo.otypes.load_types('nwqueueadapters/networktoqueue.jsonnet')
 moo.otypes.load_types('nwqueueadapters/networkobjectreceiver.jsonnet')
@@ -32,7 +31,7 @@ import dunedaq.appfwk.app as app # AddressedCmd,
 import dunedaq.dfmodules.triggerrecordbuilder as trb
 import dunedaq.dfmodules.datawriter as dw
 import dunedaq.dfmodules.hdf5datastore as hdf5ds
-#import dunedaq.dfmodules.fakedataprod as fdp
+import dunedaq.dfmodules.tpsetwriter as tpsw
 import dunedaq.nwqueueadapters.networktoqueue as ntoq
 import dunedaq.nwqueueadapters.queuetonetwork as qton
 import dunedaq.nwqueueadapters.networkobjectreceiver as nor
@@ -78,13 +77,16 @@ def generate(NETWORK_ENDPOINTS,
             app.QueueSpec(inst="trigger_decision_q", kind='FollySPSCQueue', capacity=100),
             app.QueueSpec(inst="trigger_decision_from_netq", kind='FollySPSCQueue', capacity=100),
             app.QueueSpec(inst="trigger_record_q", kind='FollySPSCQueue', capacity=100),
-            app.QueueSpec(inst="data_fragments_q", kind='FollyMPMCQueue', capacity=1000),] + [
+            app.QueueSpec(inst="data_fragments_q", kind='FollyMPMCQueue', capacity=1000),
+            ] + [
             app.QueueSpec(inst=f"data_requests_{idx}", kind='FollySPSCQueue', capacity=100)
                 for idx in range(NUMBER_OF_DATA_PRODUCERS)
             ] + [
             app.QueueSpec(inst=f"tp_data_requests_{idx}", kind='FollySPSCQueue', capacity=100)
                 for idx in range(NUMBER_OF_TP_PRODUCERS)
-        ]
+            ] + ([
+            app.QueueSpec(inst="tpsets_from_netq", kind='FollyMPMCQueue', capacity=1000),
+            ] if SOFTWARE_TPG_ENABLED else [])
 
     # Only needed to reproduce the same order as when using jsonnet
     queue_specs = app.QueueSpecs(sorted(queue_bare_specs, key=lambda x: x.inst))
@@ -115,7 +117,11 @@ def generate(NETWORK_ENDPOINTS,
         mspec(f"qton_datareq_{idx}", "QueueToNetwork", [app.QueueInfo(name="input", inst=f"data_requests_{idx}", dir="input")])  for idx in range(NUMBER_OF_DATA_PRODUCERS)
     ] + [
         mspec(f"qton_tp_datareq_{idx}", "QueueToNetwork", [app.QueueInfo(name="input", inst=f"tp_data_requests_{idx}", dir="input")])  for idx in range(NUMBER_OF_TP_PRODUCERS)
-    ]
+    ] + ([        
+        mspec(f"tpset_subscriber_{idx}", "NetworkToQueue", [app.QueueInfo(name="output", inst=f"tpsets_from_netq", dir="output")])  for idx in range(NUMBER_OF_TP_PRODUCERS)
+    ]) + ([
+        mspec("tpswriter", "TPSetWriter", [app.QueueInfo(name="tpset_source", inst="tpsets_from_netq", dir="input")])
+    ] if SOFTWARE_TPG_ENABLED else [])
 
     cmd_data['init'] = app.Init(queues=queue_specs, modules=mod_specs)
 
@@ -174,15 +180,29 @@ def generate(NETWORK_ENDPOINTS,
                                            receiver_config=nor.Conf(ipm_plugin_type="ZmqReceiver",
                                                                     address=NETWORK_ENDPOINTS[inst])))
                 for idx, inst in enumerate(NETWORK_ENDPOINTS) if "frags" in inst
-            ])
 
-
-
-
-
+            ] + [
+                (f"tpset_subscriber_{idx}", ntoq.Conf(
+                    msg_type="dunedaq::trigger::TPSet",
+                    msg_module_name="TPSetNQ",
+                    receiver_config=nor.Conf(ipm_plugin_type="ZmqSubscriber",
+                                             address=NETWORK_ENDPOINTS[f'tpsets_{idx}'],
+                                             subscriptions=["TPSets"])
+                ))
+                for idx in range(NUMBER_OF_TP_PRODUCERS)
+            ] + ([
+                ("tpswriter", tpsw.ConfParams(
+                    max_file_size_bytes=1000000000,
+                ))] if SOFTWARE_TPG_ENABLED else [])
+            )
 
     startpars = rccmd.StartParams(run=RUN_NUMBER)
-    cmd_data['start'] = acmd([("qton_token", startpars),
+    cmd_data['start'] = acmd([] +
+            ([("tpswriter", startpars),
+              ("tpset_subscriber_.*", startpars)
+            ] if SOFTWARE_TPG_ENABLED else [])
+            + [
+            ("qton_token", startpars),
             ("datawriter", startpars),
             ("ntoq_fragments_.*", startpars),
             ("qton_datareq_.*", startpars),
@@ -196,7 +216,12 @@ def generate(NETWORK_ENDPOINTS,
             ("ntoq_fragments_.*", None),
             ("datawriter", None),
             ("qton_token", None),
-            ("qton_tp_datareq_.*", None)])
+            ("qton_tp_datareq_.*", None)
+            ] + ([
+              ("tpset_subscriber_.*", None),
+              ("tpswriter", None)
+              ] if SOFTWARE_TPG_ENABLED else [])
+            )
 
     cmd_data['pause'] = acmd([("", None)])
 

--- a/python/minidaqapp/nanorc/mdapp_multiru_gen.py
+++ b/python/minidaqapp/nanorc/mdapp_multiru_gen.py
@@ -69,6 +69,7 @@ import click
 @click.option('--dqm-impl', type=click.Choice(['local','cern','pocket'], case_sensitive=False), default='local', help="DQM destination (Kafka used for cern and pocket)")
 @click.option('--pocket-url', default='127.0.0.1', help="URL for connecting to Pocket services")
 @click.option('--enable-software-tpg', is_flag=True, default=False, help="Enable software TPG")
+@click.option('--enable-tpset-writing', is_flag=True, default=False, help="Enable the writing of TPSets to disk (only works with --enable-software-tpg")
 @click.option('--use-fake-data-producers', is_flag=True, default=False, help="Use fake data producers that respond with empty fragments immediately instead of (fake) cards and DLHs")
 @click.argument('json_dir', type=click.Path())
 
@@ -77,7 +78,7 @@ def cli(partition_name, number_of_data_producers, emulator_mode, data_rate_slowd
         hsi_device_name, hsi_readout_period, hsi_endpoint_address, hsi_endpoint_partition, hsi_re_mask, hsi_fe_mask, hsi_inv_mask, hsi_source,
         use_hsi_hw, hsi_device_id, mean_hsi_signal_multiplicity, hsi_signal_emulation_mode, enabled_hsi_signals,
         ttcm_s1, ttcm_s2, trigger_activity_plugin, trigger_activity_config, trigger_candidate_plugin, trigger_candidate_config,
-        enable_raw_recording, raw_recording_output_dir, frontend_type, opmon_impl, enable_dqm, ers_impl, dqm_impl, pocket_url, enable_software_tpg, use_fake_data_producers, json_dir):
+        enable_raw_recording, raw_recording_output_dir, frontend_type, opmon_impl, enable_dqm, ers_impl, dqm_impl, pocket_url, enable_software_tpg, enable_tpset_writing, use_fake_data_producers, json_dir):
     """
       JSON_DIR: Json file output folder
     """
@@ -113,6 +114,9 @@ def cli(partition_name, number_of_data_producers, emulator_mode, data_rate_slowd
 
     if use_fake_data_producers and enable_dqm:
         raise Exception("DQM can't be used with fake data producers")
+
+    if enable_tpset_writing and not enable_software_tpg:
+        raise Exception("TPSet writing can only be used when software TPG is enabled")
 
     if token_count > 0:
         df_token_count = 0
@@ -253,7 +257,8 @@ def cli(partition_name, number_of_data_producers, emulator_mode, data_rate_slowd
         OUTPUT_PATH = output_path,
         TOKEN_COUNT = df_token_count,
         SYSTEM_TYPE = system_type,
-        SOFTWARE_TPG_ENABLED = enable_software_tpg)
+        SOFTWARE_TPG_ENABLED = enable_software_tpg,
+        TPSET_WRITING_ENABLED = enable_tpset_writing)
     console.log("dataflow cmd data:", cmd_data_dataflow)
 
     cmd_data_readout = [ readout_gen.generate(network_endpoints,


### PR DESCRIPTION
This request is for changes to the dataflow_gen.py file that is used in the mdapp_multiru confgen script.  These changes add subscriptions to listen to TPSet messages and store them on disk.  The disk-writing for the TPSets is not very well understood at this point in time, so this functionality is more of a proof-of-concept.  But, it works, and I've verified that the number of TPSet/Fragment headers in the binary file match what the Zipper module in the Trigger App reports.