### PR TITLE
add timing conn file parameter

### DIFF
--- a/python/minidaqapp/nanorc/hsi_gen.py
+++ b/python/minidaqapp/nanorc/hsi_gen.py
@@ -61,6 +61,7 @@ def generate(
         HSI_FE_MASK = 0,
         HSI_INV_MASK = 0,
         HSI_SOURCE = 1,
+        CONNECTIONS_FILE="${TIMING_SHARE}/config/etc/connections.xml",
         HSI_DEVICE_NAME="BOREAS_TLU",
         UHAL_LOG_LEVEL="notice",
     ):
@@ -124,7 +125,7 @@ def generate(
                                            )
                 ),
                         ("hsir", hsi.ConfParams(
-                        connections_file="${TIMING_SHARE}/config/etc/connections.xml",
+                        connections_file=CONNECTIONS_FILE,
                         readout_period=READOUT_PERIOD_US,
                         hsi_device_name=HSI_DEVICE_NAME,
                         uhal_log_level=UHAL_LOG_LEVEL

--- a/python/minidaqapp/nanorc/mdapp_multiru_gen.py
+++ b/python/minidaqapp/nanorc/mdapp_multiru_gen.py
@@ -36,6 +36,7 @@ import click
 @click.option('--host-hsi', default='localhost', help='Host to run the HSI app on')
 @click.option('--host-timing-hw', default='np04-srv-012.cern.ch', help='Host to run the timing hardware interface app on')
 @click.option('--control-timing-hw', is_flag=True, default=False, help='Flag to control whether we are controlling timing hardware')
+@click.option('--timing-hw-connections-file', default="${TIMING_SHARE}/config/etc/connections.xml", help='Real timing hardware only: path to hardware connections file')
 # hsi readout options
 @click.option('--hsi-device-name', default="BOREAS_TLU", help='Real HSI hardware only: device name of HSI hw')
 @click.option('--hsi-readout-period', default=1e3, help='Real HSI hardware only: Period between HSI hardware polling [us]')
@@ -74,7 +75,7 @@ import click
 @click.argument('json_dir', type=click.Path())
 
 def cli(partition_name, number_of_data_producers, emulator_mode, data_rate_slowdown_factor, run_number, trigger_rate_hz, trigger_window_before_ticks, trigger_window_after_ticks,
-        token_count, data_file, output_path, disable_trace, use_felix, host_df, host_ru, host_trigger, host_hsi, host_timing_hw, control_timing_hw,
+        token_count, data_file, output_path, disable_trace, use_felix, host_df, host_ru, host_trigger, host_hsi, host_timing_hw, control_timing_hw, timing_hw_connections_file,
         hsi_device_name, hsi_readout_period, hsi_endpoint_address, hsi_endpoint_partition, hsi_re_mask, hsi_fe_mask, hsi_inv_mask, hsi_source,
         use_hsi_hw, hsi_device_id, mean_hsi_signal_multiplicity, hsi_signal_emulation_mode, enabled_hsi_signals,
         ttcm_s1, ttcm_s2, trigger_activity_plugin, trigger_activity_config, trigger_candidate_plugin, trigger_candidate_config,
@@ -210,6 +211,7 @@ def cli(partition_name, number_of_data_producers, emulator_mode, data_rate_slowd
             RUN_NUMBER = run_number,
             NETWORK_ENDPOINTS=network_endpoints,
             TIMING_CMD_NETWORK_ENDPOINTS=timing_cmd_network_endpoints,
+            CONNECTIONS_FILE=timing_hw_connections_file,
             HSI_DEVICE_NAME=hsi_device_name,
         )
         console.log("thi cmd data:", cmd_data_thi)
@@ -218,6 +220,7 @@ def cli(partition_name, number_of_data_producers, emulator_mode, data_rate_slowd
         cmd_data_hsi = hsi_gen.generate(network_endpoints,
             RUN_NUMBER = run_number,
             CONTROL_HSI_HARDWARE=control_timing_hw,
+            CONNECTIONS_FILE=timing_hw_connections_file,
             READOUT_PERIOD_US = hsi_readout_period,
             HSI_DEVICE_NAME = hsi_device_name,
             HSI_ENDPOINT_ADDRESS = hsi_endpoint_address,

--- a/python/minidaqapp/nanorc/thi_gen.py
+++ b/python/minidaqapp/nanorc/thi_gen.py
@@ -55,6 +55,7 @@ def generate(
         GATHER_INTERVAL=1e6,
         GATHER_INTERVAL_DEBUG=10e6,
         HSI_DEVICE_NAME="",
+        CONNECTIONS_FILE="${TIMING_SHARE}/config/etc/connections.xml",
         UHAL_LOG_LEVEL="notice",
     ):
     """
@@ -76,7 +77,7 @@ def generate(
 
     thi_init_data = thi.InitParams(
                                    qinfos=app.QueueInfos([app.QueueInfo(name="hardware_commands_in", inst="ntoq_timing_cmds", dir="input")]),
-                                   connections_file="${TIMING_SHARE}/config/etc/connections.xml",
+                                   connections_file=CONNECTIONS_FILE,
                                    gather_interval=GATHER_INTERVAL,
                                    gather_interval_debug=GATHER_INTERVAL_DEBUG,
                                    monitored_device_name_master="",


### PR DESCRIPTION
Add ability to pass in a parameter containing the path to the connections file containing the IPBus entries for HSI/timing hardware. May not always want to use the connections file which comes with the release.