### PR TITLE
candidate (simpler) command-line argument capture

### DIFF
--- a/python/minidaqapp/nanorc/mdapp_multiru_gen.py
+++ b/python/minidaqapp/nanorc/mdapp_multiru_gen.py
@@ -2,7 +2,6 @@ import json
 import os
 import math
 import sys
-import glob
 import rich.traceback
 from rich.console import Console
 from os.path import exists, join
@@ -482,27 +481,9 @@ def cli(partition_name, number_of_data_producers, emulator_mode, data_rate_slowd
 
         json.dump(cfg, f, indent=4, sort_keys=True)
 
-    console.log("Generating metadata file")
-    with open(join(json_dir, 'mdapp_multiru_gen.info'), 'w') as f:
-        mdapp_dir = os.path.dirname(os.path.abspath(__file__))
-        buildinfo_files = glob.glob('**/minidaqapp_build_info.txt', recursive=True)
-        buildinfo = {}
-        for buildinfo_file in buildinfo_files:
-            if(os.path.dirname(os.path.abspath(buildinfo_file)) in mdapp_dir):
-                with open(buildinfo_file, 'r') as ff:
-                    line = ff.readline()
-                    while line: 
-                        line_parse = line.split(':')
-                        buildinfo[line_parse[0].strip()]=':'.join(line_parse[1:]).strip()
-                        line = ff.readline()
-                    
-                break
-        mdapp_info = {
-            "command_line": ' '.join(sys.argv),
-            "mdapp_dir": mdapp_dir,
-            "build_info": buildinfo
-        }
-        json.dump(mdapp_info, f, indent=4, sort_keys=True)
+    console.log("Generating text file with command line arguments")
+    with open(join(json_dir, 'mdapp_multiru_gen.txt'), 'w') as f:
+        f.write(' '.join(sys.argv) + "\n")
 
     console.log(f"MDAapp config generated in {json_dir}")
 


### PR DESCRIPTION
Alessandro and Eric...

Alessandro, on this branch, I provide a simpler command-line option capture which I believe is more in the spirit of what you were looking for.  

I'm sending this change to you for your consideration and any discussion that you would like to have with Eric about his version of the change.  

For reference, Eric's change (which is already on the patch/2.8.2 branch) produces a file with contents like the following.  I have been using this change in all of my testing this afternoon, and it has performed fine for me:
```
{
    "build_info": {},
    "command_line": "/home/biery/dunedaq/08Nov282/install/minidaqapp/lib64/python/minidaqapp/nanorc/mdapp_multiru_gen.py --host-ru localhost -d /home/biery/dunedaq/08Nov282/rundir/frames.bin -o . -s 10 --enable-dqm mdapp_4proc_dqm_AAA",
    "mdapp_dir": "/home/biery/dunedaq/08Nov282/install/minidaqapp/lib64/python/minidaqapp/nanorc"
}
```

The code on this branch produces a simpler file:
```
/home/biery/dunedaq/08Nov282/install/minidaqapp/lib64/python/minidaqapp/nanorc/mdapp_multiru_gen.py --host-ru localhost -d /home/biery/dunedaq/08Nov282/rundir/frames.bin -o . -s 10 --enable-dqm mdapp_4proc_dqm_MMM
```

In both cases, it's not obvious how to use the whole string to re-run the confgen script.  the first argument always generates a complaint, for me.  But, we can still make use of the rest of the arguments.
