### PR TITLE
Added ability to specify the TPC region name prefix

### DIFF
--- a/python/minidaqapp/nanorc/dataflow_gen.py
+++ b/python/minidaqapp/nanorc/dataflow_gen.py
@@ -53,7 +53,8 @@ def generate(NETWORK_ENDPOINTS,
         REGION_ID=0,
         SOFTWARE_TPG_ENABLED=False,
         TPSET_WRITING_ENABLED=False,
-        OPERATIONAL_ENVIRONMENT="swtest"):
+        OPERATIONAL_ENVIRONMENT="swtest",
+        TPC_REGION_NAME_PREFIX="APA"):
     """Generate the json configuration for the readout and DF process"""
 
     if SOFTWARE_TPG_ENABLED:
@@ -175,7 +176,7 @@ def generate(NETWORK_ENDPOINTS,
                                     digits_for_trigger_number = 5,
                                     path_param_list = hdf5ds.PathParamList([hdf5ds.PathParams(detector_group_type="TPC",
                                                                                               detector_group_name="TPC",
-                                                                                              region_name_prefix="APA",
+                                                                                              region_name_prefix=TPC_REGION_NAME_PREFIX,
                                                                                               element_name_prefix="Link"),
                                                                             hdf5ds.PathParams(detector_group_type="PDS",
                                                                                               detector_group_name="PDS"),

--- a/python/minidaqapp/nanorc/mdapp_multiru_gen.py
+++ b/python/minidaqapp/nanorc/mdapp_multiru_gen.py
@@ -80,6 +80,7 @@ import click
 @click.option('--dqm-rawdisplay-params', nargs=3, default=[60, 10, 50], help="Parameters that control the data sent for the raw display plot")
 @click.option('--dqm-meanrms-params', nargs=3, default=[10, 1, 100], help="Parameters that control the data sent for the mean/rms plot")
 @click.option('--dqm-fourier-params', nargs=3, default=[600, 60, 100], help="Parameters that control the data sent for the fourier transform plot")
+@click.option('--tpc-region-name-prefix', default='APA', help="Prefix to be used for the 'Region' Group name inside the HDF5 file")
 @click.option('--op-env', default='swtest', help="Operational environment - used for raw data filename prefix and HDF5 Attribute inside the files")
 @click.argument('json_dir', type=click.Path())
 
@@ -90,7 +91,7 @@ def cli(partition_name, number_of_data_producers, emulator_mode, data_rate_slowd
         ttcm_s1, ttcm_s2, trigger_activity_plugin, trigger_activity_config, trigger_candidate_plugin, trigger_candidate_config,
         enable_raw_recording, raw_recording_output_dir, frontend_type, opmon_impl, enable_dqm, ers_impl, dqm_impl, pocket_url, enable_software_tpg, enable_tpset_writing, use_fake_data_producers, dqm_cmap,
         dqm_rawdisplay_params, dqm_meanrms_params, dqm_fourier_params,
-        op_env, json_dir):
+        op_env, tpc_region_name_prefix, json_dir):
 
     """
       JSON_DIR: Json file output folder
@@ -290,7 +291,8 @@ def cli(partition_name, number_of_data_producers, emulator_mode, data_rate_slowd
         REGION_ID = region_id,
         SOFTWARE_TPG_ENABLED = enable_software_tpg,
         TPSET_WRITING_ENABLED = enable_tpset_writing,
-        OPERATIONAL_ENVIRONMENT = op_env)
+        OPERATIONAL_ENVIRONMENT = op_env,
+        TPC_REGION_NAME_PREFIX = tpc_region_name_prefix)
     console.log("dataflow cmd data:", cmd_data_dataflow)
 
     cmd_data_readout = [ readout_gen.generate(network_endpoints,


### PR DESCRIPTION
As requested by Florian and others working in the control room.

Please note that this changes does *not* affect the detector Group name in the HDF5 file.  That will remain "TPC".  It only affect the level below that, where "APA" can be changed to "CRP", for example.

```
GROUP "TriggerRecord00032" {
      GROUP "TPC" {
         GROUP "CRP000" {
            DATASET "Link00" {
               DATATYPE  H5T_STD_I8LE
               DATASPACE  SIMPLE { ( 37200, 1 ) / ( 37200, 1 ) }
            }
            DATASET "Link01" {
               DATATYPE  H5T_STD_I8LE
               DATASPACE  SIMPLE { ( 37200, 1 ) / ( 37200, 1 ) }
            }
         }
      }
      DATASET "TriggerRecordHeader" {
         DATATYPE  H5T_STD_I8LE
         DATASPACE  SIMPLE { ( 128, 1 ) / ( 128, 1 ) }
      }
   }

```
