### PR TITLE
Provide a mdapp_mutlru confgen option for setting the maximum raw data file size

### DIFF
--- a/python/minidaqapp/nanorc/dataflow_gen.py
+++ b/python/minidaqapp/nanorc/dataflow_gen.py
@@ -54,7 +54,8 @@ def generate(NETWORK_ENDPOINTS,
         SOFTWARE_TPG_ENABLED=False,
         TPSET_WRITING_ENABLED=False,
         OPERATIONAL_ENVIRONMENT="swtest",
-        TPC_REGION_NAME_PREFIX="APA"):
+        TPC_REGION_NAME_PREFIX="APA",
+        MAX_FILE_SIZE=4*1024*1024*1024):
     """Generate the json configuration for the readout and DF process"""
 
     if SOFTWARE_TPG_ENABLED:
@@ -166,7 +167,7 @@ def generate(NETWORK_ENDPOINTS,
                                 version = 3,
                                 operational_environment = OPERATIONAL_ENVIRONMENT,
                                 directory_path = OUTPUT_PATH,
-                                max_file_size_bytes = 4294967296,
+                                max_file_size_bytes = MAX_FILE_SIZE,
                                 disable_unique_filename_suffix = False,
                                 filename_parameters = hdf5ds.FileNameParams(overall_prefix = OPERATIONAL_ENVIRONMENT,
                                     digits_for_run_number = 6,

--- a/python/minidaqapp/nanorc/mdapp_multiru_gen.py
+++ b/python/minidaqapp/nanorc/mdapp_multiru_gen.py
@@ -80,8 +80,9 @@ import click
 @click.option('--dqm-rawdisplay-params', nargs=3, default=[60, 10, 50], help="Parameters that control the data sent for the raw display plot")
 @click.option('--dqm-meanrms-params', nargs=3, default=[10, 1, 100], help="Parameters that control the data sent for the mean/rms plot")
 @click.option('--dqm-fourier-params', nargs=3, default=[600, 60, 100], help="Parameters that control the data sent for the fourier transform plot")
-@click.option('--tpc-region-name-prefix', default='APA', help="Prefix to be used for the 'Region' Group name inside the HDF5 file")
 @click.option('--op-env', default='swtest', help="Operational environment - used for raw data filename prefix and HDF5 Attribute inside the files")
+@click.option('--tpc-region-name-prefix', default='APA', help="Prefix to be used for the 'Region' Group name inside the HDF5 file")
+@click.option('--max-file-size', default=4*1024*1024*1024, help="The size threshold when raw data files are close (in bytes)")
 @click.argument('json_dir', type=click.Path())
 
 def cli(partition_name, number_of_data_producers, emulator_mode, data_rate_slowdown_factor, run_number, trigger_rate_hz, trigger_window_before_ticks, trigger_window_after_ticks,
@@ -91,7 +92,7 @@ def cli(partition_name, number_of_data_producers, emulator_mode, data_rate_slowd
         ttcm_s1, ttcm_s2, trigger_activity_plugin, trigger_activity_config, trigger_candidate_plugin, trigger_candidate_config,
         enable_raw_recording, raw_recording_output_dir, frontend_type, opmon_impl, enable_dqm, ers_impl, dqm_impl, pocket_url, enable_software_tpg, enable_tpset_writing, use_fake_data_producers, dqm_cmap,
         dqm_rawdisplay_params, dqm_meanrms_params, dqm_fourier_params,
-        op_env, tpc_region_name_prefix, json_dir):
+        op_env, tpc_region_name_prefix, max_file_size, json_dir):
 
     """
       JSON_DIR: Json file output folder
@@ -305,7 +306,8 @@ def cli(partition_name, number_of_data_producers, emulator_mode, data_rate_slowd
         SOFTWARE_TPG_ENABLED = enable_software_tpg,
         TPSET_WRITING_ENABLED = enable_tpset_writing,
         OPERATIONAL_ENVIRONMENT = op_env,
-        TPC_REGION_NAME_PREFIX = tpc_region_name_prefix)
+        TPC_REGION_NAME_PREFIX = tpc_region_name_prefix,
+        MAX_FILE_SIZE = max_file_size)
     console.log("dataflow cmd data:", cmd_data_dataflow)
 
     cmd_data_readout = [ readout_gen.generate(network_endpoints,

--- a/python/minidaqapp/nanorc/mdapp_multiru_gen.py
+++ b/python/minidaqapp/nanorc/mdapp_multiru_gen.py
@@ -82,7 +82,7 @@ import click
 @click.option('--dqm-fourier-params', nargs=3, default=[600, 60, 100], help="Parameters that control the data sent for the fourier transform plot")
 @click.option('--op-env', default='swtest', help="Operational environment - used for raw data filename prefix and HDF5 Attribute inside the files")
 @click.option('--tpc-region-name-prefix', default='APA', help="Prefix to be used for the 'Region' Group name inside the HDF5 file")
-@click.option('--max-file-size', default=4*1024*1024*1024, help="The size threshold when raw data files are close (in bytes)")
+@click.option('--max-file-size', default=4*1024*1024*1024, help="The size threshold when raw data files are closed (in bytes)")
 @click.argument('json_dir', type=click.Path())
 
 def cli(partition_name, number_of_data_producers, emulator_mode, data_rate_slowdown_factor, run_number, trigger_rate_hz, trigger_window_before_ticks, trigger_window_after_ticks,


### PR DESCRIPTION
We probably should have done this earlier, but...
I realized that it would be very helpful to be able to set the maximum raw data file size when running integration tests, so I have added it to the mdapp_multru_gen script.  This PR is for that addition.
Once this PR is approved and merged, I will submit some changes in the _dfmodules_ repo to take advantage of it.