### PR TITLE
Post-2.8.2 confgen fix for multiple separate DQM processes

### DIFF
--- a/python/minidaqapp/nanorc/dqm_gen.py
+++ b/python/minidaqapp/nanorc/dqm_gen.py
@@ -110,7 +110,7 @@ def generate(NETWORK_ENDPOINTS,
               [app.QueueInfo(name="output", inst="data_fragments_q_dqm", dir="output")
                ])]
     mod_specs += [
-        mspec(f"qton_datareq_dqm_{idx}", "QueueToNetwork",
+        mspec(f"qton_datareq_dqm_{idx+MIN_LINK}", "QueueToNetwork",
               [app.QueueInfo(name="input", inst=f"data_requests_dqm_{idx+MIN_LINK}", dir="input")
                ]) for idx in range(NUMBER_OF_DATA_PRODUCERS)]
 
@@ -120,9 +120,9 @@ def generate(NETWORK_ENDPOINTS,
                 (f"qton_datareq_dqm_{idx}", qton.Conf(msg_type="dunedaq::dfmessages::DataRequest",
                                             msg_module_name="DataRequestNQ",
                                             sender_config=nos.Conf(ipm_plugin_type="ZmqSender",
-                                                                   address=NETWORK_ENDPOINTS[f"datareq_dqm_{HOSTIDX}_{idx}"],
+                                                                   address=NETWORK_ENDPOINTS[f"datareq_dqm_{idx}"],
                                                                    stype="msgpack")))
-                                            for idx in range(NUMBER_OF_DATA_PRODUCERS)
+                                            for idx in range(MIN_LINK, MAX_LINK)
             ] + [
                 ("ntoq_fragments_dqm", ntoq.Conf(msg_type="std::unique_ptr<dunedaq::daqdataformats::Fragment>",
                                            msg_module_name="FragmentNQ",

--- a/python/minidaqapp/nanorc/mdapp_multiru_gen.py
+++ b/python/minidaqapp/nanorc/mdapp_multiru_gen.py
@@ -216,7 +216,7 @@ def cli(partition_name, number_of_data_producers, emulator_mode, data_rate_slowd
 
         if enable_dqm:
             for idx in range(number_of_data_producers):
-                network_endpoints[f"datareq_dqm_{hostidx}_{idx}"] = "tcp://{host_ru" + f"{hostidx}" + "}:" + f"{port}"
+                network_endpoints[f"datareq_dqm_{hostidx*number_of_data_producers+idx}"] = "tcp://{host_ru" + f"{hostidx}" + "}:" + f"{port}"
                 port = port + 1
             network_endpoints[f"fragx_dqm_{hostidx}"] = "tcp://{host_ru" + f"{hostidx}" + "}:" + f"{port}"
             port = port + 1

--- a/python/minidaqapp/nanorc/readout_gen.py
+++ b/python/minidaqapp/nanorc/readout_gen.py
@@ -357,8 +357,8 @@ def generate(NETWORK_ENDPOINTS,
         conf_list.extend( (f"ntoq_datareq_dqm_{idx}", ntoq.Conf(msg_type="dunedaq::dfmessages::DataRequest",
                                         msg_module_name="DataRequestNQ",
                                         receiver_config=nor.Conf(ipm_plugin_type="ZmqReceiver",
-                                                                 address=NETWORK_ENDPOINTS[f"datareq_dqm_{HOSTIDX}_{idx}"])))
-                          for idx in range(NUMBER_OF_DATA_PRODUCERS) )
+                                                                 address=NETWORK_ENDPOINTS[f"datareq_dqm_{idx}"])))
+                          for idx in range(MIN_LINK,MAX_LINK) )
 
     if SOFTWARE_TPG_ENABLED:
         conf_list.extend([


### PR DESCRIPTION
In testing dunedaq-v2.8.2, Florian noticed that the 2nd, 3rd, etc. DQM processes were reporting errors and not processing events.
I tracked this down to additional confgen bugs, and the branch associated with this PR contains the fixes.
Juan, I went back to using network endpoints in the range [0..14].  One of the problems that I found was that I hadn't switched to the mode of using [0_0..0_4,1_0..1..4, etc] everywhere it was needed.  Instead of modifying those additional instances to use `{HOSTIDX}_{idx}`, I just went back to the original model of `network_endpoints[f"datareq_dqm_{hostidx*number_of_data_producers+idx`.
Another problem was in the naming of the qton_datareq_dqm_* modules in the dqm confgen.

With these changes, I can run multiple DQM processes without seeing errors during a run.  Of course, my tests were with emulated data, and further tests would be appreciated.
