### PR TITLE
Change NtoQ to FragmentReceiver and some cleanup

### DIFF
--- a/python/minidaqapp/nanorc/mdapp_multiru_gen.py
+++ b/python/minidaqapp/nanorc/mdapp_multiru_gen.py
@@ -113,8 +113,9 @@ def cli(partition_name, number_of_data_producers, emulator_mode, data_rate_slowd
 
     console.log("Loading dataflow config generator")
     from . import dataflow_gen
-    console.log("Loading dqm config generator")
-    from . import dqm_gen
+    if enable_dqm:
+        console.log("Loading dqm config generator")
+        from . import dqm_gen
     console.log("Loading readout config generator")
     from . import readout_gen
     console.log("Loading trigger config generator")


### PR DESCRIPTION
These are the changes from NetworkToQueue to FragmentReceiver in DQM. I had to change the queue name of the fragments since in the fragment receiver it is hardcoded to `data_fragments_q`. Works fine in my tests with and without (nothing should change in those) DQM enabled. I have added a second commit with a check not to load the DQM config if DQM is not enabled, which will save a few seconds when generating configs without DQM