### PR TITLE
Changed MLT-DFO queue type from StdDeQueue to FollySPSCQueue

### DIFF
--- a/python/minidaqapp/nanorc/trigger_gen.py
+++ b/python/minidaqapp/nanorc/trigger_gen.py
@@ -110,7 +110,7 @@ def generate(
     # Define modules and queues
     queue_bare_specs = [
         app.QueueSpec(inst='trigger_candidate_q', kind='FollyMPMCQueue', capacity=1000),
-        app.QueueSpec(inst='trigger_decision_q', kind='StdDeQueue', capacity=2)
+        app.QueueSpec(inst='trigger_decision_q', kind='FollySPSCQueue', capacity=2)
     ]
 
     if SOFTWARE_TPG_ENABLED:


### PR DESCRIPTION
This will probably only work reliably with software areas based on N21-12-16 or later, since that is the first nightly build that uses a newer version of the Folly library.  If an older nightly/Folly version are used with this change, the symptom will be that no trigger inhibits get generated.