### PR TITLE
Add dqm applications to the app list only if dqm is enabled

### DIFF
--- a/python/minidaqapp/nanorc/mdapp_multiru_gen.py
+++ b/python/minidaqapp/nanorc/mdapp_multiru_gen.py
@@ -402,7 +402,7 @@ def cli(partition_name, number_of_data_producers, emulator_mode, data_rate_slowd
 
     console.log(f"Generating top-level command json files")
 
-    start_order = app_df + [app_trigger] + app_ru + [app_hsi] + app_dqm
+    start_order = app_df + [app_trigger] + app_ru + [app_hsi] + (app_dqm if enable_dqm else [])
     if not control_timing_hw and use_hsi_hw:
         resume_order = [app_trigger]
     else:


### PR DESCRIPTION
Dqm applications are currently added to the list of applications regardless of whether the dqm is enabled or not.
New version of nanorc are becoming less tolerant to not-existing applications.
This PR patches the config generation to fix this issue by only adding dqm apps to the list if the `--enable-dqm` is `True`