### PR TITLE
Remove unused vars and args

### DIFF
--- a/python/minidaqapp/newconf/dataflow_gen.py
+++ b/python/minidaqapp/newconf/dataflow_gen.py
@@ -50,13 +50,9 @@ QUEUE_POP_WAIT_MS = 100
 
 class DataFlowApp(App):
     def __init__(self,
-                 # NW_SPECS,
                  RU_CONFIG=[],
                  HOSTIDX=0,
-                 RUN_NUMBER=333,
                  OUTPUT_PATH=".",
-                 SYSTEM_TYPE="TPC",
-                 SOFTWARE_TPG_ENABLED=False,
                  TPSET_WRITING_ENABLED=False,
                  PARTITION="UNKNOWN",
                  OPERATIONAL_ENVIRONMENT="swtest",

--- a/python/minidaqapp/newconf/mdapp_multiru_gen.py
+++ b/python/minidaqapp/newconf/mdapp_multiru_gen.py
@@ -228,9 +228,6 @@ def cli(partition_name, number_of_data_producers, emulator_mode, data_rate_slowd
         ru_channel_counts[region_id[regionidx]] += number_of_data_producers
         if len(region_id) != 1: regionidx = regionidx + 1
 
-    for nw in the_system.network_endpoints:
-        print(f'{nwmgr.Name} {nwmgr.Topic} {nwmgr.Address}')
-        
     if control_timing_hw:
         pass
         # PL: TODO
@@ -276,7 +273,6 @@ def cli(partition_name, number_of_data_producers, emulator_mode, data_rate_slowd
             PARTITION=partition_name,
             HOST=host_hsi)
 
-        # the_system.apps["hsi"] = util.App(modulegraph=mgraph_hsi, host=host_hsi)
     console.log("hsi cmd data:", the_system.apps["hsi"])
 
     the_system.apps['trigger'] = TriggerApp(
@@ -288,15 +284,12 @@ def cli(partition_name, number_of_data_producers, emulator_mode, data_rate_slowd
         CANDIDATE_PLUGIN = trigger_candidate_plugin,
         CANDIDATE_CONFIG = eval(trigger_candidate_config),
         TOKEN_COUNT = trigemu_token_count,
-        SYSTEM_TYPE = system_type,
         TTCM_S1=ttcm_s1,
         TTCM_S2=ttcm_s2,
         TRIGGER_WINDOW_BEFORE_TICKS = trigger_window_before_ticks,
         TRIGGER_WINDOW_AFTER_TICKS = trigger_window_after_ticks,
         PARTITION=partition_name,
         HOST=host_trigger)
-
-    # console.log("trigger cmd data:", cmd_data_trigger)
 
     #-------------------------------------------------------------------
     # Readout apps
@@ -323,11 +316,8 @@ def cli(partition_name, number_of_data_producers, emulator_mode, data_rate_slowd
             for link in range(min_link, max_link):
                 the_system.network_endpoints.append(nwmgr.Connection(name=f"{partition_name}.tpsets_apa{apa_idx}_link{link}", topics=["TPSets"], address = f"tcp://{{host_{ru_app_name}}}:{the_system.next_unassigned_port()}"))
 
-    for nw in the_system.network_endpoints:
-        print(f'{nwmgr.Name} {nwmgr.Topic} {nwmgr.Address}')
         
 
-    mgraphs_readout = []
     for i,host in enumerate(host_ru):
         ru_name = ru_app_names[i]
         the_system.apps[ru_name] = ReadoutApp(PARTITION=partition_name,
@@ -337,7 +327,6 @@ def cli(partition_name, number_of_data_producers, emulator_mode, data_rate_slowd
                                               DATA_FILE = data_file,
                                               FLX_INPUT = use_felix,
                                               SSP_INPUT = use_ssp,
-                                              CLOCK_SPEED_HZ = CLOCK_SPEED_HZ,
                                               RUIDX = i,
                                               RAW_RECORDING_ENABLED = enable_raw_recording,
                                               RAW_RECORDING_OUTPUT_DIR = raw_recording_output_dir,
@@ -354,7 +343,6 @@ def cli(partition_name, number_of_data_producers, emulator_mode, data_rate_slowd
             the_system.apps[dqm_name] = DQMApp(
                 RU_CONFIG = ru_configs,
                 EMULATOR_MODE = emulator_mode,
-                RUN_NUMBER = run_number,
                 DATA_FILE = data_file,
                 CLOCK_SPEED_HZ = CLOCK_SPEED_HZ,
                 RUIDX = i,
@@ -377,10 +365,7 @@ def cli(partition_name, number_of_data_producers, emulator_mode, data_rate_slowd
         the_system.apps[app_name] = DataFlowApp(
             RU_CONFIG = ru_configs,
             HOSTIDX = i,
-            RUN_NUMBER = run_number,
             OUTPUT_PATH = output_path,
-            SYSTEM_TYPE = system_type,
-            SOFTWARE_TPG_ENABLED = enable_software_tpg,
             TPSET_WRITING_ENABLED = enable_tpset_writing,
             PARTITION=partition_name,
             OPERATIONAL_ENVIRONMENT = op_env,

--- a/python/minidaqapp/newconf/readout_gen.py
+++ b/python/minidaqapp/newconf/readout_gen.py
@@ -52,15 +52,12 @@ QUEUE_POP_WAIT_MS = 100
 
 class ReadoutApp(App):
     def __init__(self,
-                 # NW_SPECS,
                  RU_CONFIG=[],
                  EMULATOR_MODE=False,
                  DATA_RATE_SLOWDOWN_FACTOR=1,
-                 RUN_NUMBER=333, 
                  DATA_FILE="./frames.bin",
                  FLX_INPUT=False,
                  SSP_INPUT=True,
-                 CLOCK_SPEED_HZ=50000000,
                  RUIDX=0,
                  RAW_RECORDING_ENABLED=False,
                  RAW_RECORDING_OUTPUT_DIR=".",
@@ -72,15 +69,7 @@ class ReadoutApp(App):
                  LATENCY_BUFFER_SIZE=499968,
                  HOST="localhost"):
         """Generate the json configuration for the readout and DF process"""
-        NUMBER_OF_DATA_PRODUCERS = len(RU_CONFIG)
-        cmd_data = {}
-    
-        required_eps = {f'{PARTITION}.timesync_{RUIDX}'}
-        # if not required_eps.issubset([nw.name for nw in NW_SPECS]):
-        #     raise RuntimeError(f"ERROR: not all the required endpoints ({', '.join(required_eps)}) found in list of endpoints {' '.join([nw.name for nw in NW_SPECS])}")
-    
-        RATE_KHZ = CLOCK_SPEED_HZ / (25 * 12 * DATA_RATE_SLOWDOWN_FACTOR * 1000)
-    
+        
         MIN_LINK = RU_CONFIG[RUIDX]["start_channel"]
         MAX_LINK = MIN_LINK + RU_CONFIG[RUIDX]["channel_count"]
         

--- a/python/minidaqapp/newconf/trigger_gen.py
+++ b/python/minidaqapp/newconf/trigger_gen.py
@@ -64,7 +64,6 @@ class TriggerApp(App):
                  CANDIDATE_CONFIG: int = dict(prescale=10),
 
                  TOKEN_COUNT: int = 10,
-                 SYSTEM_TYPE = 'wib',
                  TTCM_S1: int = 1,
                  TTCM_S2: int = 2,
                  TRIGGER_WINDOW_BEFORE_TICKS: int = 1000,


### PR DESCRIPTION
When running `pylint` on `minidaqapp`, one finds the following unused vars:
```
> pylint *.py |egrep 'unused-(variable|argument)'
dataflow_gen.py:56:17: W0613: Unused argument 'RUN_NUMBER' (unused-argument)
dataflow_gen.py:58:17: W0613: Unused argument 'SYSTEM_TYPE' (unused-argument)
dataflow_gen.py:59:17: W0613: Unused argument 'SOFTWARE_TPG_ENABLED' (unused-argument)
dqm_gen.py:38:17: W0613: Unused argument 'EMULATOR_MODE' (unused-argument)
dqm_gen.py:39:17: W0613: Unused argument 'RUN_NUMBER' (unused-argument)
dqm_gen.py:40:17: W0613: Unused argument 'DATA_FILE' (unused-argument)
dqm_gen.py:44:17: W0613: Unused argument 'DQM_ENABLED' (unused-argument)
dqm_gen.py:54:8: W0612: Unused variable 'cmd_data' (unused-variable)
dqm_gen.py:56:8: W0612: Unused variable 'required_eps' (unused-variable)
fake_hsi_gen.py:51:17: W0613: Unused argument 'HSI_DEVICE_ID' (unused-argument)
fake_hsi_gen.py:59:8: W0612: Unused variable 'required_eps' (unused-variable)
hsi_gen.py:58:17: W0613: Unused argument 'RUN_NUMBER' (unused-argument)
hsi_gen.py:60:17: W0613: Unused argument 'TRIGGER_RATE_HZ' (unused-argument)
hsi_gen.py:87:8: W0612: Unused variable 'hsi_controller_init_data' (unused-variable)
mdapp_multiru_gen.py:101:122: W0613: Unused argument 'host_timing_hw' (unused-argument)
mdapp_multiru_gen.py:101:157: W0613: Unused argument 'timing_hw_connections_file' (unused-argument)
mdapp_multiru_gen.py:102:8: W0613: Unused argument 'hsi_device_name' (unused-argument)
mdapp_multiru_gen.py:102:25: W0613: Unused argument 'hsi_readout_period' (unused-argument)
mdapp_multiru_gen.py:102:45: W0613: Unused argument 'hsi_endpoint_address' (unused-argument)
mdapp_multiru_gen.py:102:67: W0613: Unused argument 'hsi_endpoint_partition' (unused-argument)
mdapp_multiru_gen.py:102:91: W0613: Unused argument 'hsi_re_mask' (unused-argument)
mdapp_multiru_gen.py:102:104: W0613: Unused argument 'hsi_fe_mask' (unused-argument)
mdapp_multiru_gen.py:102:117: W0613: Unused argument 'hsi_inv_mask' (unused-argument)
mdapp_multiru_gen.py:102:131: W0613: Unused argument 'hsi_source' (unused-argument)
mdapp_multiru_gen.py:231:8: W0612: Unused variable 'nw' (unused-variable)
mdapp_multiru_gen.py:330:4: W0612: Unused variable 'mgraphs_readout' (unused-variable)
readout_gen.py:59:17: W0613: Unused argument 'RUN_NUMBER' (unused-argument)
readout_gen.py:75:8: W0612: Unused variable 'NUMBER_OF_DATA_PRODUCERS' (unused-variable)
readout_gen.py:76:8: W0612: Unused variable 'cmd_data' (unused-variable)
readout_gen.py:78:8: W0612: Unused variable 'required_eps' (unused-variable)
readout_gen.py:82:8: W0612: Unused variable 'RATE_KHZ' (unused-variable)
thi_gen.py:53:17: W0613: Unused argument 'RUN_NUMBER' (unused-argument)
thi_gen.py:61:17: W0613: Unused argument 'PARTITION' (unused-argument)
thi_gen.py:76:8: W0612: Unused variable 'thi_init_data' (unused-variable)
trigger_gen.py:67:17: W0613: Unused argument 'SYSTEM_TYPE' (unused-argument)
```

This PR fixes some of it. I didn't want to touch the THI, DQM and (Fake-)HSI apps because Stoyan and Juan Miguel are working on it; so maybe we can wait until they finish and merge their changes, and have another pass at this afterwards.
